### PR TITLE
Fix media id will be cover by URL's id

### DIFF
--- a/media/cropper.go
+++ b/media/cropper.go
@@ -19,7 +19,7 @@ import (
 func getParams(ctx *web.EventContext) (field string, id int, thumb string, cfg *media_library.MediaBoxConfig) {
 	field = ctx.R.FormValue("field")
 
-	id = ctx.ParamAsInt("id")
+	id = ctx.ParamAsInt("media_id")
 	thumb = ctx.R.FormValue("thumb")
 	cfg = stringToCfg(ctx.R.FormValue("cfg"))
 	return
@@ -80,7 +80,7 @@ func loadImageCropper(mb *Builder) web.EventFunc {
 									BeforeScript("locals.cropping = true").
 									EventFunc(cropImageEvent).
 									Query("field", field).
-									Query("id", fmt.Sprint(id)).
+									Query("media_id", fmt.Sprint(id)).
 									Query("thumb", thumb).
 									FieldValue("cfg", h.JSONString(cfg)).
 									Go()),

--- a/media/filechooser.go
+++ b/media/filechooser.go
@@ -235,7 +235,7 @@ func fileChooserDialogContent(mb *Builder, field string, ctx *web.EventContext,
 							BeforeScript(fmt.Sprintf("locals.%s = true", croppingVar)).
 							EventFunc(chooseFileEvent).
 							Query("field", field).
-							Query("id", fmt.Sprint(f.ID)).
+							Query("media_id", fmt.Sprint(f.ID)).
 							FieldValue("cfg", h.JSONString(cfg)).
 							Go(), field != mediaLibraryListField).
 						AttrIf("@click", imgClickVars, field == mediaLibraryListField),
@@ -249,7 +249,7 @@ func fileChooserDialogContent(mb *Builder, field string, ctx *web.EventContext,
 							Attr("@change", web.Plaid().
 								EventFunc(updateDescriptionEvent).
 								Query("field", field).
-								Query("id", fmt.Sprint(f.ID)).
+								Query("media_id", fmt.Sprint(f.ID)).
 								FieldValue("cfg", h.JSONString(cfg)).
 								FieldValue("CurrentDescription", web.Var("$event.target.value")).
 								Go(),
@@ -267,7 +267,7 @@ func fileChooserDialogContent(mb *Builder, field string, ctx *web.EventContext,
 									web.Plaid().
 										EventFunc(deleteConfirmationEvent).
 										Query("field", field).
-										Query("id", fmt.Sprint(f.ID)).
+										Query("media_id", fmt.Sprint(f.ID)).
 										FieldValue("cfg", h.JSONString(cfg)).
 										Go(),
 								),
@@ -433,7 +433,7 @@ func chooseFile(mb *Builder) web.EventFunc {
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
 		db := mb.db
 		field := ctx.R.FormValue("field")
-		id := ctx.ParamAsInt("id")
+		id := ctx.ParamAsInt("media_id")
 		cfg := stringToCfg(ctx.R.FormValue("cfg"))
 
 		var m media_library.MediaLibrary

--- a/media/media_box.go
+++ b/media/media_box.go
@@ -201,7 +201,7 @@ func mediaBoxThumb(msgr *Messages, cfg *media_library.MediaBoxConfig,
 		card.Attr("@click", web.Plaid().
 			EventFunc(loadImageCropperEvent).
 			Query("field", field).
-			Query("id", fmt.Sprint(f.ID)).
+			Query("media_id", fmt.Sprint(f.ID)).
 			Query("thumb", thumb).
 			FieldValue("cfg", h.JSONString(cfg)).
 			Go())
@@ -219,7 +219,7 @@ func deleteConfirmation(mb *Builder) web.EventFunc {
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
 		msgr := i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 		field := ctx.R.FormValue("field")
-		id := ctx.R.FormValue("id")
+		id := ctx.R.FormValue("media_id")
 		cfg := ctx.R.FormValue("cfg")
 
 		r.UpdatePortals = append(r.UpdatePortals, &web.PortalUpdate{
@@ -241,7 +241,7 @@ func deleteConfirmation(mb *Builder) web.EventFunc {
 							Attr("@click", web.Plaid().
 								EventFunc(doDeleteEvent).
 								Query("field", field).
-								Query("id", id).
+								Query("media_id", id).
 								FieldValue("cfg", cfg).
 								Go()),
 					),
@@ -260,7 +260,7 @@ func doDelete(mb *Builder) web.EventFunc {
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
 		db := mb.db
 		field := ctx.R.FormValue("field")
-		id := ctx.R.FormValue("id")
+		id := ctx.R.FormValue("media_id")
 		cfg := ctx.R.FormValue("cfg")
 
 		var obj media_library.MediaLibrary
@@ -472,7 +472,7 @@ func updateDescription(mb *Builder) web.EventFunc {
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
 		db := mb.db
 		field := ctx.R.FormValue("field")
-		id := ctx.R.FormValue("id")
+		id := ctx.R.FormValue("media_id")
 		cfg := ctx.R.FormValue("cfg")
 
 		var obj media_library.MediaLibrary


### PR DESCRIPTION
On the detail page, "id" may appear in the URL, which will cover the media's id.
Rename id to media_id