### PR TITLE
fix: `Code is required` is displayed in the wrong field

### DIFF
--- a/example/admin/product_config.go
+++ b/example/admin/product_config.go
@@ -155,7 +155,7 @@ func configProduct(b *presets.Builder, _ *gorm.DB, wb *worker.Builder, publisher
 	eb.ValidateFunc(func(obj interface{}, ctx *web.EventContext) (err web.ValidationErrors) {
 		u := obj.(*models.Product)
 		if u.Code == "" {
-			err.FieldError("Name", "Code is required")
+			err.FieldError("Code", "Code is required")
 		}
 		if u.Name == "" {
 			err.FieldError("Name", "Name is required")


### PR DESCRIPTION
<img width="786" alt="image" src="https://github.com/qor5/admin/assets/57855015/34c6d9f2-10cb-47ea-bc9b-cf33f654c8bf">
