### PR TITLE
chore: fix the changes with combine of vuetify + vuetifyx

### DIFF
--- a/docs/docsrc/examples/examples_vuetify/mux.go
+++ b/docs/docsrc/examples/examples_vuetify/mux.go
@@ -81,14 +81,11 @@ func DemoVuetifyLayout(in web.PageFunc) (out web.PageFunc) {
 }
 
 // @snippet_end
-
 func Mux(mux *http.ServeMux) http.Handler {
 	// @snippet_begin(ComponentsPackSample)
 	mux.Handle("/assets/main.js",
 		web.PacksHandler("text/javascript",
 			vuetifyx.JSComponentsPack(),
-			Vuetify(),
-			JSComponentsPack(),
 			web.JSComponentsPack(),
 		),
 	)
@@ -116,7 +113,7 @@ func Mux(mux *http.ServeMux) http.Handler {
 	// @snippet_end
 
 	// @snippet_begin(VuetifyComponentsPackSample)
-	HandleMaterialDesignIcons("", mux)
+	vuetifyx.HandleMaterialDesignIcons("", mux)
 	// @snippet_end
 
 	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {

--- a/docs/docsrc/examples/examples_vuetifyx/mux.go
+++ b/docs/docsrc/examples/examples_vuetifyx/mux.go
@@ -7,16 +7,13 @@ import (
 	"github.com/qor5/admin/v3/docs/docsrc/examples/examples_vuetify"
 	"github.com/qor5/web/v3"
 	"github.com/qor5/web/v3/examples"
-	. "github.com/qor5/x/v3/ui/vuetify"
 	"github.com/qor5/x/v3/ui/vuetifyx"
 )
 
 func Mux(mux *http.ServeMux, prefix string) http.Handler {
 	mux.Handle("/assets/main.js",
 		web.PacksHandler("text/javascript",
-			JSComponentsPack(),
 			vuetifyx.JSComponentsPack(),
-			Vuetify(),
 			web.JSComponentsPack(),
 		),
 	)
@@ -27,7 +24,7 @@ func Mux(mux *http.ServeMux, prefix string) http.Handler {
 		),
 	)
 
-	HandleMaterialDesignIcons(prefix, mux)
+	vuetifyx.HandleMaterialDesignIcons(prefix, mux)
 
 	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(assets.Favicon)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pquerna/otp v1.4.0
 	github.com/qor/oss v0.0.0-20240729105053-88484a799a79
 	github.com/qor5/web/v3 v3.0.6-0.20240808073627-bd2003d12e2c
-	github.com/qor5/x/v3 v3.0.7-0.20240814061055-cf2440fdaa13
+	github.com/qor5/x/v3 v3.0.7-0.20240815022109-4a747e211a86
 	github.com/samber/lo v1.46.0
 	github.com/shurcooL/sanitized_anchor_name v1.0.0
 	github.com/spf13/cast v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/qor5/x/v3 v3.0.7-0.20240814054459-34e2d7f1eead h1:A7o4Q60RJjeK9xqHCC+
 github.com/qor5/x/v3 v3.0.7-0.20240814054459-34e2d7f1eead/go.mod h1:p8LBZGmJ9pozop2jMACV5tN/1gkpAskteOhlwcfFxpw=
 github.com/qor5/x/v3 v3.0.7-0.20240814061055-cf2440fdaa13 h1:EeWAwQGJYeOTpC/7WGb1/bOL8g3H87KdLbaAhok0H7A=
 github.com/qor5/x/v3 v3.0.7-0.20240814061055-cf2440fdaa13/go.mod h1:p8LBZGmJ9pozop2jMACV5tN/1gkpAskteOhlwcfFxpw=
+github.com/qor5/x/v3 v3.0.7-0.20240815022109-4a747e211a86 h1:HFtxsaqO3b+2PlQjEYdPBnZJAy4FPjUcZEfKFATYzoc=
+github.com/qor5/x/v3 v3.0.7-0.20240815022109-4a747e211a86/go.mod h1:p8LBZGmJ9pozop2jMACV5tN/1gkpAskteOhlwcfFxpw=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/presets/presets.go
+++ b/presets/presets.go
@@ -1284,8 +1284,6 @@ func (b *Builder) initMux() {
 	mainJSPath := b.prefix + "/assets/main.js"
 	mux.Handle("GET "+mainJSPath,
 		ub.PacksHandler("text/javascript",
-			Vuetify(),
-			JSComponentsPack(),
 			vuetifyx.JSComponentsPack(),
 			web.JSComponentsPack(),
 		),
@@ -1299,7 +1297,7 @@ func (b *Builder) initMux() {
 		),
 	)
 
-	HandleMaterialDesignIcons(b.prefix, mux)
+	vuetifyx.HandleMaterialDesignIcons(b.prefix, mux)
 
 	log.Println("mounted url:", vueJSPath)
 


### PR DESCRIPTION
1. 固定了vuetify 的版本号，js和css都是3.16.4，避免每次拉最新cdn，api变动带来的潜在bug
2. 现在main.js 只需要引用 vuetifyxjs.min.js (原 vuetify.js + vuetifyx.umd.js) 和 core.js
3. 这次提交依赖项，不然go编译不通过 https://github.com/qor5/x/pull/245