### PR TITLE
feat: add minimum value attribute to number field in field_defaults

### DIFF
--- a/presets/field_defaults.go
+++ b/presets/field_defaults.go
@@ -186,6 +186,7 @@ func cfNumber(obj interface{}, field *FieldContext, ctx *web.EventContext) h.HTM
 		Type("number").
 		Attr(VFieldError(field.FormKey, fmt.Sprint(reflectutils.MustGet(obj, field.Name)), field.Errors)...).
 		Label(field.Label).
+		Attr(":min", "0").
 		Disabled(field.Disabled)
 }
 


### PR DESCRIPTION
- Added a minimum value attribute (min="0") to the number field rendering function to enforce non-negative input.