### PR TITLE
feat: add MaxItems configuration to ListEditorBuilder and update Nested method

### DIFF
--- a/presets/field.go
+++ b/presets/field.go
@@ -285,6 +285,12 @@ type SortListItemsEvent struct {
 
 func (*SortListItemsEvent) nested() {}
 
+type MaxItems struct {
+	Limit int
+}
+
+func (*MaxItems) nested() {}
+
 func (b *FieldBuilder) Nested(fb *FieldsBuilder, cfgs ...NestedConfig) (r *FieldBuilder) {
 	b.nestedFieldsBuilder = fb
 	switch b.rt.Kind() {
@@ -293,6 +299,7 @@ func (b *FieldBuilder) Nested(fb *FieldsBuilder, cfgs ...NestedConfig) (r *Field
 		var addListItemRowEvent string
 		var removeListItemRowEvent string
 		var sortListItemsEvent string
+		var maxItems int
 		for _, cfg := range cfgs {
 			switch t := cfg.(type) {
 			case *DisplayFieldInSorter:
@@ -303,6 +310,8 @@ func (b *FieldBuilder) Nested(fb *FieldsBuilder, cfgs ...NestedConfig) (r *Field
 				removeListItemRowEvent = t.Event
 			case *SortListItemsEvent:
 				sortListItemsEvent = t.Event
+			case *MaxItems:
+				maxItems = t.Limit
 			default:
 				panic("unknown nested config")
 			}
@@ -312,7 +321,8 @@ func (b *FieldBuilder) Nested(fb *FieldsBuilder, cfgs ...NestedConfig) (r *Field
 				DisplayFieldInSorter(displayFieldInSorter).
 				AddListItemRowEvnet(addListItemRowEvent).
 				RemoveListItemRowEvent(removeListItemRowEvent).
-				SortListItemsEvent(sortListItemsEvent)
+				SortListItemsEvent(sortListItemsEvent).
+				MaxItems(maxItems)
 		})
 	default:
 		b.ComponentFunc(func(obj interface{}, field *FieldContext, ctx *web.EventContext) h.HTMLComponent {

--- a/presets/listeditor.go
+++ b/presets/listeditor.go
@@ -23,6 +23,7 @@ type ListEditorBuilder struct {
 	addListItemRowEvent    string
 	removeListItemRowEvent string
 	sortListItemsEvent     string
+	maxItems               int
 }
 
 type ListSorter struct {
@@ -80,6 +81,11 @@ func (b *ListEditorBuilder) SortListItemsEvent(v string) (r *ListEditorBuilder) 
 		return b
 	}
 	b.sortListItemsEvent = v
+	return b
+}
+
+func (b *ListEditorBuilder) MaxItems(v int) (r *ListEditorBuilder) {
+	b.maxItems = v
 	return b
 }
 
@@ -200,6 +206,7 @@ func (b *ListEditorBuilder) MarshalHTML(c context.Context) (r []byte, err error)
 						Variant(VariantText).
 						Color("primary").
 						Attr("id", addRowBtnId).
+						Disabled(b.maxItems > 0 && reflect.ValueOf(b.value).Len() >= b.maxItems).
 						Attr("@click", web.Plaid().
 							URL(b.fieldContext.ModelInfo.ListingHref()).
 							EventFunc(b.addListItemRowEvent).
@@ -208,8 +215,7 @@ func (b *ListEditorBuilder) MarshalHTML(c context.Context) (r []byte, err error)
 							Query(ParamID, ctx.R.FormValue(ParamID)).
 							Query(ParamOverlay, ctx.R.FormValue(ParamOverlay)).
 							Query(ParamAddRowFormKey, b.fieldContext.FormKey).
-							Go(),
-						),
+							Go()),
 				),
 			).Attr("v-show", h.JSONString(!isSortStart)).
 				Class("mt-1 mb-4"),


### PR DESCRIPTION
- Introduced MaxItems struct to define a limit for list items.
- Updated ListEditorBuilder to include MaxItems method for setting the maximum item limit.
- Modified Nested method in FieldBuilder to handle MaxItems configuration.