### PR TITLE
feat(pagebuilder): add FindContainerByName and GetRenderFunc public accessors

### DIFF
--- a/pagebuilder/builder.go
+++ b/pagebuilder/builder.go
@@ -1010,6 +1010,20 @@ func (b *Builder) ContainerByName(name string) (r *ContainerBuilder) {
 	panic(fmt.Sprintf("No container: %s", name))
 }
 
+// FindContainerByName returns the container builder for the given name,
+// or nil if no container with that name is registered. Unlike
+// ContainerByName it does not panic, making it safe for public-facing
+// routes where a stale DB row may reference a container type that has
+// since been removed.
+func (b *Builder) FindContainerByName(name string) *ContainerBuilder {
+	for _, cb := range b.containerBuilders {
+		if cb.name == name {
+			return cb
+		}
+	}
+	return nil
+}
+
 type ContainerBuilder struct {
 	builder      *Builder
 	name         string
@@ -1224,6 +1238,11 @@ func (b *ContainerBuilder) warpSaver() {
 func (b *ContainerBuilder) RenderFunc(v RenderFunc) *ContainerBuilder {
 	b.renderFunc = v
 	return b
+}
+
+// GetRenderFunc returns the registered render function for this container.
+func (b *ContainerBuilder) GetRenderFunc() RenderFunc {
+	return b.renderFunc
 }
 
 func (b *ContainerBuilder) Cover(v string) *ContainerBuilder {


### PR DESCRIPTION
## Summary

Two public accessor methods for `pagebuilder.Builder` and `ContainerBuilder`:

- **`Builder.FindContainerByName(name)`** — non-panicking variant of `ContainerByName`. Returns `nil` when no container with the given name is registered, making it safe for public-facing routes where a stale DB row may reference a container type that has since been removed.

- **`ContainerBuilder.GetRenderFunc()`** — exposes the registered render function so callers outside the pagebuilder (e.g. a public route rendering a page's containers) can dispatch rendering without duplicating the model-name → render-function mapping.

## Test plan

- [x] `FindContainerByName` returns the correct builder for registered names
- [x] `FindContainerByName` returns nil for unregistered names (no panic)
- [x] `GetRenderFunc` returns the function set via `RenderFunc()`