### PR TITLE
feat(presets): add FieldBuilder.GetLabel and webp to static file regex

### DIFF
--- a/presets/field.go
+++ b/presets/field.go
@@ -159,6 +159,11 @@ func (b *FieldBuilder) Label(v string) (r *FieldBuilder) {
 	return b
 }
 
+// GetLabel returns the configured label for this field.
+func (b *FieldBuilder) GetLabel() string {
+	return b.label
+}
+
 func (b *FieldBuilder) Clone() (r *FieldBuilder) {
 	r = &FieldBuilder{}
 	r.name = b.name

--- a/presets/presets.go
+++ b/presets/presets.go
@@ -94,7 +94,7 @@ const (
 	OpenConfirmDialog = "presets_ConfirmDialog"
 )
 
-var staticFileRe = regexp.MustCompile(`\.(css|js|gif|jpg|jpeg|png|ico|svg|ttf|eot|woff|woff2|js\.map)$`)
+var staticFileRe = regexp.MustCompile(`\.(css|js|gif|jpg|jpeg|png|ico|svg|ttf|eot|woff|woff2|js\.map|webp)$`)
 
 func New() *Builder {
 	l, _ := zap.NewDevelopment()


### PR DESCRIPTION
## Summary

Two small improvements to the presets package:

- **`FieldBuilder.GetLabel()`** — returns the configured label string. Useful for code that introspects field metadata to generate reports, dynamic forms, or documentation based on model configuration.

- **webp in `staticFileRe`** — `.webp` assets are now recognized as static files, ensuring they get proper caching headers like other image formats.

## Test plan

- [x] `GetLabel()` returns the label set via `Label()`
- [x] `.webp` URLs are matched by `staticFileRe`