### PR TITLE
fix: upgrade go-chi/chi/v5 to v5.3.0 (Aikido CVE-2025-69725)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.17.0
-	github.com/go-chi/chi/v5 v5.2.2
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
-github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
-github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/kit v0.12.1-0.20220826005032-a7ba4fa4e289 h1:468Nv6YtYO38Z+pFL6fRSVILGfdTFPei9ksVneiUHUc=


### PR DESCRIPTION
## Summary
Resolves the Aikido open-source finding for **CVE-2025-69725** — an open-redirect in go-chi/chi's `RedirectSlashes` middleware (backslashes in URL paths interpreted as protocol-relative URLs).

- `github.com/go-chi/chi/v5` **v5.2.2 → v5.3.0** (CVE affects `>=5.2.2,<5.2.4`; patched in 5.2.4 — v5.3.0 fully covers it)

## Aikido Issues Resolved
- sub-issue 330730389 (group 32647874) — CVE-2025-69725, priority 47
  https://app.aikido.dev/issues/32647874/detail?singleIssueFilter=330730389&status=open&team_id_filter=31569

## Verification
- `go mod tidy` clean
- `go build ./...` compiles (only a pre-existing `bimg`/`pkg-config` cgo error remains in this sandbox — unrelated to chi and present on `main`)
- chi-using packages build clean (`./example`, `./presets/...`, doc example servers)

## Deployment Note
Skill does not touch `release-*` branches. Merging this PR and any release promotion is handled per team policy.