### PR TITLE
ci: set persist-credentials:false on Go CI checkout (Aikido)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          # Don't leave the GITHUB_TOKEN in .git/config after checkout — no later
+          # step pushes back to the repo (Aikido: actions/checkout persist Git credentials).
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
## Summary
Hardens the `Go` CI workflow against the Aikido SAST finding **"GitHub Action actions/checkout persist Git credentials in workflow"** (Low / SAST).

`actions/checkout@v2+` leaves the default `GITHUB_TOKEN` in the repo's local `.git/config` for the rest of the job unless `persist-credentials: false` is set. Subsequent steps or compromised third-party actions could then read it. The `Go` job here only builds and tests — it never performs an authenticated `git push` back to the repo — so the token does not need to persist.

## Change
- `.github/workflows/go.yml`: add `persist-credentials: false` to the `actions/checkout` step.

That's the only change. `submodules: true` is kept (the repo currently has no submodules, but the flag is left untouched); the checkout still fetches everything it needs during the action itself.

## Verification
- YAML / actionlint parse the workflow cleanly (the pre-existing "action version too old" warnings for checkout@v3 / setup-go@v3 / aws-actions@v2 are unrelated to this change and intentionally left alone).
- **The real test is this PR's own CI run**: the `Go` job runs `go build ./...` + `go test ./...`. If dependency fetching relied on the persisted checkout token, the build would fail here — so a green run confirms `persist-credentials: false` is safe for this repo.

## Deployment Note
Skill does not touch `release-*` branches. Merging is handled per team policy.