### PR TITLE
fix(presets): scroll to first validation error & persistent error notice (KGM-4566)

### DIFF
--- a/docs/docsrc/examples/examples_presets/editing_test.go
+++ b/docs/docsrc/examples/examples_presets/editing_test.go
@@ -36,7 +36,8 @@ func TestPresetsEditingValidate(t *testing.T) {
 					AddField("Name", "").
 					BuildEventFuncRequest()
 			},
-			ExpectPortalUpdate0ContainsInOrder: []string{"timeout='2000'", "name must not be empty"},
+			// error notices are now persistent (timeout -1) so a save failure is not missed
+			ExpectPortalUpdate0ContainsInOrder: []string{"timeout='-1'", "name must not be empty"},
 		},
 	}
 

--- a/presets/editing.go
+++ b/presets/editing.go
@@ -325,11 +325,23 @@ func (b *EditingBuilder) editFormFor(obj interface{}, ctx *web.EventContext) h.H
 			}
 		}
 		if text != "" {
+			// Success messages auto-dismiss; error notices stay until the user closes
+			// them, so a save failure is never missed by someone scrolled away from it.
+			timeout := 2000
+			var closeBtn h.HTMLComponent
+			if color == "error" {
+				timeout = -1
+				closeBtn = web.Slot(
+					VBtn("").Icon("mdi-close").Variant(VariantText).Size(SizeSmall).
+						Attr("@click", "locals.show = false"),
+				).Name("actions")
+			}
 			notice = web.Scope(
 				VSnackbar(
 					h.Div().Style("white-space: pre-wrap").Text(fmt.Sprintf(`{{ %q }}`, text)),
+					closeBtn,
 				).Location("top").
-					Timeout(2000).
+					Timeout(timeout).
 					Color(color).
 					Attr("v-model", "locals.show"),
 			).VSlot("{ locals }").Init(`{ show: true }`)
@@ -700,6 +712,10 @@ func (b *EditingBuilder) UpdateOverlayContent(
 		Name: p,
 		Body: b.editFormFor(obj, ctx),
 	})
+
+	if vErr, ok := ctx.Flash.(*web.ValidationErrors); ok && vErr.HaveErrors() {
+		web.AppendRunScripts(r, ScrollToFirstErrorScript(p))
+	}
 }
 
 func (b *EditingBuilder) Section(sections ...*SectionBuilder) *EditingBuilder {

--- a/presets/integration/example_test.go
+++ b/presets/integration/example_test.go
@@ -77,6 +77,36 @@ func TestExample(t *testing.T) {
 			},
 		},
 		{
+			Name: "Update with validation error scrolls to first error field",
+			ReqFunc: func() *http.Request {
+				customerData.TruncatePut(dbr)
+				return NewMultipartBuilder().
+					PageURL("/admin/my_customers").
+					EventFunc(actions.Update).
+					Query(presets.ParamID, "11").
+					AddField("ID", "11").
+					AddField("Name", "abc"). // < 5 chars, fails the ValidateFunc
+					BuildEventFuncRequest()
+			},
+			ExpectPortalUpdate0ContainsInOrder: []string{"input more than 5 chars"},
+			ExpectRunScriptContainsInOrder:     []string{"scrollIntoView"},
+		},
+		{
+			Name: "Update with validation error shows a persistent error notice",
+			ReqFunc: func() *http.Request {
+				customerData.TruncatePut(dbr)
+				return NewMultipartBuilder().
+					PageURL("/admin/my_customers").
+					EventFunc(actions.Update).
+					Query(presets.ParamID, "11").
+					AddField("ID", "11").
+					AddField("Name", "abc").
+					BuildEventFuncRequest()
+			},
+			// error notice must not auto-dismiss (persistent) and stays closable.
+			ExpectPortalUpdate0ContainsInOrder: []string{":timeout='-1'", "there are some errors"},
+		},
+		{
 			Name: "Create",
 			ReqFunc: func() *http.Request {
 				emptyCustomerData.TruncatePut(dbr)

--- a/presets/integration/section_test.go
+++ b/presets/integration/section_test.go
@@ -296,6 +296,54 @@ func TestDetailFieldBuilder(t *testing.T) {
 	}
 }
 
+// TestSectionSaveValidationErrorScrollsToFirstError verifies that saving a section
+// with validation errors returns a script that scrolls the first errored field into
+// view, mirroring the editing-form behavior (KGM-4566).
+func TestSectionSaveValidationErrorScrollsToFirstError(t *testing.T) {
+	db := TestDB
+	db.AutoMigrate(&ParameterSetting{})
+	sqlDB, _ := db.DB()
+
+	b := presets.New().URIPrefix("/ps")
+	b.DataOperator(gorm2op.DataOperator(db))
+	mb := b.Model(&ParameterSetting{})
+	detail := mb.Detailing("Detail").Drawer(true)
+	section := presets.NewSectionBuilder(mb, "Detail").
+		ViewComponentFunc(func(obj interface{}, field *presets.FieldContext, ctx *web.EventContext) h.HTMLComponent {
+			return h.Div(h.Text(obj.(*ParameterSetting).DisplayName))
+		}).
+		EditComponentFunc(func(obj interface{}, field *presets.FieldContext, ctx *web.EventContext) h.HTMLComponent {
+			ps := obj.(*ParameterSetting)
+			return h.Div(
+				v.VTextField().Attr(web.VField(fmt.Sprintf("%s.DisplayName", field.FormKey), ps.DisplayName)...),
+			)
+		}).
+		Editing("DisplayName")
+	section.WrapValidator(func(_ presets.ValidateFunc) presets.ValidateFunc {
+		return func(obj interface{}, ctx *web.EventContext) (err web.ValidationErrors) {
+			if len(obj.(*ParameterSetting).DisplayName) < 5 {
+				err.FieldError("Detail.DisplayName", "input more than 5 chars")
+			}
+			return
+		}
+	})
+	detail.Section(section)
+
+	multipartestutils.RunCase(t, multipartestutils.TestCase{
+		Name: "section save with validation error scrolls to first error",
+		ReqFunc: func() *http.Request {
+			settingData.TruncatePut(sqlDB)
+			return multipartestutils.NewMultipartBuilder().
+				PageURL("/ps/parameter-settings").
+				EventFunc("section_save_Detail").
+				Query(presets.ParamID, "1").
+				AddField("Detail.DisplayName", "abc"). // < 5 chars
+				BuildEventFuncRequest()
+		},
+		ExpectRunScriptContainsInOrder: []string{"scrollIntoView"},
+	}, b)
+}
+
 // TestWrapSaveFunc tests the WrapSaveFunc method of SectionBuilder
 func TestWrapSaveFunc(t *testing.T) {
 	db := TestDB
@@ -305,12 +353,12 @@ func TestWrapSaveFunc(t *testing.T) {
 		t.Fatalf("Failed to create tables: %v", err)
 	}
 
-	// Get sql.DB from gorm.DB for test fixtures
+	// Get sql.DB from gorm.DB for test fixtures. Do NOT close it: db is the shared
+	// TestDB pool, and closing it here would break any test that runs afterwards.
 	sqlDB, err := db.DB()
 	if err != nil {
 		t.Fatalf("Failed to get sql.DB: %v", err)
 	}
-	defer sqlDB.Close()
 
 	// Create test data
 	settingData := gofixtures.Data(gofixtures.Sql(`

--- a/presets/section.go
+++ b/presets/section.go
@@ -1110,11 +1110,12 @@ func (b *SectionBuilder) SaveDetailField(ctx *web.EventContext) (r web.EventResp
 		}
 	}
 
-	if _, ok := ctx.Flash.(*web.ValidationErrors); ok {
+	if vErr, ok := ctx.Flash.(*web.ValidationErrors); ok && vErr.HaveErrors() {
 		r.UpdatePortals = append(r.UpdatePortals, &web.PortalUpdate{
 			Name: b.FieldPortalName(),
 			Body: b.editComponent(obj, field, ctx),
 		})
+		web.AppendRunScripts(&r, ScrollToFirstErrorScript(b.FieldPortalName()))
 		return
 	}
 

--- a/presets/utils.go
+++ b/presets/utils.go
@@ -38,6 +38,23 @@ func ShowSnackbarScript(msg, color string) string {
 	return fmt.Sprintf(`vars.presetsMessage = { show: true, message: %q, color: %q}`, msg, color)
 }
 
+// ScrollToFirstErrorScript returns a script that, after the editing form portal
+// re-renders with validation errors, scrolls the first errored field into view and
+// focuses it. Without this a user who scrolled down (e.g. to the Save button) sees no
+// visible change on save failure, because the error lives at the top / next to a field
+// that is now off-screen. It targets the given portal so it never picks up an unrelated
+// form; a short timeout lets Vuetify apply the `.v-input--error` class after the patch.
+func ScrollToFirstErrorScript(portalName string) string {
+	return fmt.Sprintf(`setTimeout(function(){
+  var root = document.querySelector('go-plaid-portal[portal-name=%q]') || document;
+  var el = root.querySelector('.v-input--error');
+  if (!el) { return }
+  el.scrollIntoView({behavior:'smooth', block:'center'});
+  var focusable = el.querySelector('input, textarea, select, [contenteditable], [tabindex]');
+  if (focusable) { focusable.focus({preventScroll:true}); }
+}, 100)`, portalName)
+}
+
 func ShowMessage(r *web.EventResponse, msg, color string) {
 	script := ShowSnackbarScript(msg, color)
 	if script == "" {


### PR DESCRIPTION
## Problem (KGM-4566)

When editing customer info in the admin console, if a required field (e.g. email) is left blank and the user clicks **保存する / Save**, server-side validation fails — but the user (scrolled down near the Save button) sees **no visible change** and assumes the save succeeded.

Root cause: on validation failure, `UpdateOverlayContent` re-renders the **entire** drawer/form portal, which resets the scroll to the top. The error surfaces are both easy to miss:
- **Global error** → a top `VSnackbar` that **auto-dismisses in 2s**.
- **Field error** → shown inline next to the field, which is now **off-screen above**.

## Fix

Adopted option ② from the ticket (locate the error), because option ① (disable Save) can't cover server-only validation and has an untouched-field gap.

- **Scroll to first error** — new exported helper `ScrollToFirstErrorScript(portalName)`. After the portal re-renders, it scrolls the first `.v-input--error` field (DOM order = top-most on the page) into view and focuses it. Injected at the single re-render choke point in `EditingBuilder.UpdateOverlayContent`, and mirrored in `SectionBuilder.SaveDetailField` (横展開). It no-ops when no errored field is present, so global-error / permission-denied paths stay safe. It does **not** fire on the debounced live-validate path, only on Save.
- **Persistent error notice** — the top error snackbar now uses `timeout -1` with a close button; success messages still auto-dismiss after 2s.
- **Drive-by fix** — removed `defer sqlDB.Close()` in `TestWrapSaveFunc`, which closed the shared `TestDB` pool and broke any test running afterwards.

## Tests

- `example_test.go` — save with validation error emits `scrollIntoView`; error notice renders `:timeout='-1'`.
- `section_test.go` — section save with validation error emits `scrollIntoView`.
- `go test ./presets/...` → 108 passed; `go build ./...` OK.

Note: tests assert the server response contract (script emitted + notice persistent). The runtime scroll is standard `scrollIntoView`; visual confirmation needs the running admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)