### PR TITLE
fix(presets): align list editor row delete button with row content

### DIFF
--- a/presets/listeditor.go
+++ b/presets/listeditor.go
@@ -144,19 +144,21 @@ func (b *ListEditorBuilder) MarshalHTML(c context.Context) (r []byte, err error)
 	if b.value != nil {
 		form = b.fieldContext.NestedFieldsBuilder.ToComponentForEach(b.fieldContext, b.value, ctx, func(obj interface{}, formKey string, content h.HTMLComponent, ctx *web.EventContext) h.HTMLComponent {
 			return VCard(
-				h.If(!b.fieldContext.Disabled && hasUpdatePermission,
-					VBtn("").Icon("mdi-delete").Class("float-right ma-2").
-						Attr("@click", web.Plaid().
-							URL(b.fieldContext.ModelInfo.ListingHref()).
-							EventFunc(b.removeListItemRowEvent).
-							Queries(ctx.Queries()).
-							Query(AddRowBtnKey(b.fieldContext.FormKey), "").
-							Query(ParamID, id).
-							Query(ParamOverlay, ctx.R.FormValue(ParamOverlay)).
-							Query(ParamRemoveRowFormKey, formKey).
-							Go()),
-				),
-				content,
+				h.Div(
+					h.Div(content).Class("flex-grow-1"),
+					h.If(!b.fieldContext.Disabled && hasUpdatePermission,
+						VBtn("").Icon("mdi-delete").Class("ml-2 align-self-center").
+							Attr("@click", web.Plaid().
+								URL(b.fieldContext.ModelInfo.ListingHref()).
+								EventFunc(b.removeListItemRowEvent).
+								Queries(ctx.Queries()).
+								Query(AddRowBtnKey(b.fieldContext.FormKey), "").
+								Query(ParamID, id).
+								Query(ParamOverlay, ctx.R.FormValue(ParamOverlay)).
+								Query(ParamRemoveRowFormKey, formKey).
+								Go()),
+					),
+				).Class("d-flex"),
 			).Class("mx-0 mb-2 px-4 pb-0 pt-4").Variant(VariantOutlined)
 		})
 	}


### PR DESCRIPTION
## Problem

The list editor's per-row delete button is rendered with `float-right ma-2`, which pins it to the card's top-right corner regardless of the row height:

- On rows whose nested fields stack vertically (e.g. a Start/End date pair), the button sits next to the first field only and looks detached from the row.
- Even on single-field rows it is slightly off the field's vertical center because of the card's asymmetric padding (`pt-4 pb-0`).

Reported downstream in kakuyasu seller portal ([KGM-4586](https://theplanttokyo.atlassian.net/browse/KGM-4586)), but it affects every `Nested` slice field rendered by `ListEditorBuilder`.

## Fix

Lay each row card out with flex instead of float: the content wraps in a `flex-grow-1` div and the delete button follows it with `align-self-center`, so it stays vertically centered against the row content at any row height. Vuetify utility classes only; the click binding is unchanged.

## Testing

- `go test ./presets/...` passes (including integration).
- Verified end-to-end in the kakuyasu seller portal (Delivery Unavailable Date editing panel) via a local `go.mod` replace: on a two-field (Start/End) row the button now centers between the fields, on a single-field row it aligns with the input, and row deletion still works.

Supersedes #1093 (same commit, resubmitted from an in-repo branch now that write access is available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)