### PR TITLE
fix(presets): center list editor row content and button within the row card

### DIFF
--- a/presets/listeditor.go
+++ b/presets/listeditor.go
@@ -145,7 +145,7 @@ func (b *ListEditorBuilder) MarshalHTML(c context.Context) (r []byte, err error)
 		form = b.fieldContext.NestedFieldsBuilder.ToComponentForEach(b.fieldContext, b.value, ctx, func(obj interface{}, formKey string, content h.HTMLComponent, ctx *web.EventContext) h.HTMLComponent {
 			return VCard(
 				h.Div(
-					h.Div(content).Class("flex-grow-1"),
+					h.Div(content).Class("flex-grow-1 align-self-center"),
 					h.If(!b.fieldContext.Disabled && hasUpdatePermission,
 						VBtn("").Icon("mdi-delete").Class("ml-2 align-self-center").
 							Attr("@click", web.Plaid().

--- a/presets/listeditor.go
+++ b/presets/listeditor.go
@@ -159,7 +159,7 @@ func (b *ListEditorBuilder) MarshalHTML(c context.Context) (r []byte, err error)
 								Go()),
 					),
 				).Class("d-flex"),
-			).Class("mx-0 mb-2 px-4 pb-0 pt-4").Variant(VariantOutlined)
+			).Class("mx-0 mb-2 pa-4").Variant(VariantOutlined)
 		})
 	}
 


### PR DESCRIPTION
## Problem

Follow-up to #1094. Two remaining alignment defects in the list editor row cards (reported downstream in [KGM-4586](https://theplanttokyo.atlassian.net/browse/KGM-4586)):

1. When a row's content is shorter than the 48px delete button (e.g. a single compact input), the flex row's height is driven by the button, the content column stretches to that height (default `align-items: stretch`) and sticks to its top — the button sits (48 − content)/2 px below the input's centerline.
2. The card's `pt-4 pb-0` padding relied on the row content ending with a v-input details placeholder to supply the bottom gap. Content without one (hide-details inputs, plain components) gets pinned against the card's bottom border, visibly off the card's vertical centerline.

## Fix

- `align-self-center` on the content column: a short content block centers against the button instead of stretching; rows taller than the button define the row height themselves and are unaffected.
- `pa-4` on the row card: symmetric vertical padding, so the card's spacing no longer depends on the content's internal structure. Rows whose content ends with a details placeholder gain 16px of bottom padding (16/36 total) — slightly roomier, but the card no longer collapses onto content that doesn't carry one.

## Testing

- `go test ./presets/...` passes.
- Verified in the kakuyasu seller portal via a local `go.mod` replace: with hide-details inputs, both a single-input row and a two-field row measure a 0.0px offset between the delete button center and the card centerline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)