### PR TITLE
fix(presets): center list editor row delete button within the row card

### DIFF
--- a/presets/listeditor.go
+++ b/presets/listeditor.go
@@ -143,22 +143,29 @@ func (b *ListEditorBuilder) MarshalHTML(c context.Context) (r []byte, err error)
 
 	if b.value != nil {
 		form = b.fieldContext.NestedFieldsBuilder.ToComponentForEach(b.fieldContext, b.value, ctx, func(obj interface{}, formKey string, content h.HTMLComponent, ctx *web.EventContext) h.HTMLComponent {
+			showDelete := !b.fieldContext.Disabled && hasUpdatePermission
+			contentWrap := h.Div(content)
+			if showDelete {
+				// Keep the content clear of the absolutely positioned button.
+				contentWrap.Class("pe-14")
+			}
 			return VCard(
-				h.Div(
-					h.Div(content).Class("flex-grow-1"),
-					h.If(!b.fieldContext.Disabled && hasUpdatePermission,
-						VBtn("").Icon("mdi-delete").Class("ml-2 align-self-center").
-							Attr("@click", web.Plaid().
-								URL(b.fieldContext.ModelInfo.ListingHref()).
-								EventFunc(b.removeListItemRowEvent).
-								Queries(ctx.Queries()).
-								Query(AddRowBtnKey(b.fieldContext.FormKey), "").
-								Query(ParamID, id).
-								Query(ParamOverlay, ctx.R.FormValue(ParamOverlay)).
-								Query(ParamRemoveRowFormKey, formKey).
-								Go()),
-					),
-				).Class("d-flex"),
+				h.If(showDelete,
+					// Anchor to the card's vertical center so the button stays
+					// centered whatever the row content's height is.
+					VBtn("").Icon("mdi-delete").Class("position-absolute").
+						Attr("style", "top:50%;right:16px;transform:translateY(-50%)").
+						Attr("@click", web.Plaid().
+							URL(b.fieldContext.ModelInfo.ListingHref()).
+							EventFunc(b.removeListItemRowEvent).
+							Queries(ctx.Queries()).
+							Query(AddRowBtnKey(b.fieldContext.FormKey), "").
+							Query(ParamID, id).
+							Query(ParamOverlay, ctx.R.FormValue(ParamOverlay)).
+							Query(ParamRemoveRowFormKey, formKey).
+							Go()),
+				),
+				contentWrap,
 			).Class("mx-0 mb-2 px-4 pb-0 pt-4").Variant(VariantOutlined)
 		})
 	}


### PR DESCRIPTION
## Problem

Follow-up to #1094, reported downstream in [KGM-4586](https://theplanttokyo.atlassian.net/browse/KGM-4586). The row delete button's vertical position depends on the row content's height and internal structure: content-relative layout (float before #1094, flex after) drifts off the card's vertical centerline whenever the content stacks multiple fields, carries labels, or ends with a v-input validation-message placeholder.

## Fix

Anchor the button to the **card** instead of the content: `position-absolute` with `top:50%; right:16px; translateY(-50%)` (VCard is already `position: relative`), and pad the content wrapper with `pe-14` so fields stay clear of the button. The row content layout — card padding, heights, field positions — is byte-for-byte unchanged from the current rendering; only the button moves.

Supersedes #1095: that approach (symmetric card padding + flex centering) also centered the button, but changed every row card's height/spacing as a side effect. This one is strictly scoped to the button.

## Testing

- `go test ./presets/...` passes.
- Verified in the kakuyasu seller portal via a local `go.mod` replace: the delete button measures a 0.0px offset from the card's vertical center on a single-input row, a two-field (Start/End) row, and multi-row lists (sort icon unaffected); the input's right edge keeps an 8px gap to the button; card heights identical to the pre-change rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)