### PR TITLE
feat(redirection): support directory-form internal targets

### DIFF
--- a/redirection/event.go
+++ b/redirection/event.go
@@ -118,7 +118,7 @@ func (b *Builder) checkObjects(ctx *web.EventContext, r *web.EventResponse, msgr
 	// check  target object is exist
 	for index, record := range records {
 		row := strconv.Itoa(index + 1)
-		if !strings.HasPrefix(record.Target, "http") && !b.checkObjectExists(ctx.R.Context(), record.Target) {
+		if !strings.HasPrefix(record.Target, "http") && !b.checkTargetExists(ctx.R.Context(), record.Target) {
 			errorRows = append(errorRows, row)
 		}
 	}

--- a/redirection/redirection_test.go
+++ b/redirection/redirection_test.go
@@ -7,8 +7,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/qor5/web/v3"
 	"github.com/qor5/x/v3/gormx"
+	s3x "github.com/qor5/x/v3/oss/s3"
 	"github.com/theplant/gofixtures"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -129,5 +133,93 @@ func TestCheckObjects(t *testing.T) {
 	if !b.checkObjects(ctx, r, Messages_en_US, []Redirection{}) {
 		t.Fatalf("No Objects Is Passed")
 		return
+	}
+}
+
+func newTestS3Client(t *testing.T, handler http.Handler) *s3x.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &s3x.Client{
+		S3: awss3.New(awss3.Options{
+			BaseEndpoint: aws.String(server.URL),
+			UsePathStyle: true,
+			Region:       "us-east-1",
+			Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+		}),
+		Config: &s3x.Config{Bucket: "test-bucket"},
+	}
+}
+
+func TestCheckTargetExists(t *testing.T) {
+	client := newTestS3Client(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		existing := map[string]bool{
+			"/test-bucket/index.html":     true,
+			"/test-bucket/503/index.html": true,
+		}
+		if r.Method == http.MethodHead && existing[r.URL.Path] {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	builder := &Builder{s3Client: client}
+
+	cases := []struct {
+		name   string
+		target string
+		expect bool
+	}{
+		{name: "existing object", target: "/503/index.html", expect: true},
+		{name: "directory form resolves to index document", target: "/503/", expect: true},
+		{name: "root resolves to index document", target: "/", expect: true},
+		{name: "missing object", target: "/missing.html", expect: false},
+		{name: "directory form without index document", target: "/missing/", expect: false},
+		{name: "no trailing slash is not treated as directory", target: "/503", expect: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := builder.checkTargetExists(context.Background(), c.target); got != c.expect {
+				t.Errorf("checkTargetExists(%q) = %t, want %t", c.target, got, c.expect)
+			}
+		})
+	}
+}
+
+func TestRedirectionKeepsDirectoryTargetSlash(t *testing.T) {
+	redirectLocations := make(map[string]string)
+	client := newTestS3Client(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut:
+			redirectLocations[r.URL.Path] = r.Header.Get("x-amz-website-redirect-location")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	builder := &Builder{s3Client: client}
+
+	cases := []struct {
+		name   string
+		source string
+		target string
+		expect string
+	}{
+		{name: "directory form keeps trailing slash", source: "/old/a.html", target: "/503/", expect: "/503/"},
+		{name: "file target unchanged", source: "/old/b.html", target: "/503/index.html", expect: "/503/index.html"},
+		{name: "absolute url unchanged", source: "/old/c.html", target: "https://example.com/x/", expect: "https://example.com/x/"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := builder.redirection(context.Background(), &Redirection{Source: c.source, Target: c.target}); err != nil {
+				t.Fatalf("redirection() error: %v", err)
+			}
+			key := "/test-bucket" + c.source
+			if got := redirectLocations[key]; got != c.expect {
+				t.Errorf("WebsiteRedirectLocation for %s = %q, want %q", c.source, got, c.expect)
+			}
+		})
 	}
 }

--- a/redirection/storage.go
+++ b/redirection/storage.go
@@ -21,6 +21,7 @@ import (
 const (
 	defaultConcurrency = 10
 	defaultTimeout     = 5
+	indexDocument      = "index.html"
 )
 
 type uploadFiles struct {
@@ -105,6 +106,12 @@ func (b *Builder) redirection(ctx context.Context, record *Redirection) (err err
 	target := record.Target
 	if !strings.HasPrefix(target, "http") {
 		target = path.Join("/", record.Target)
+		// path.Join drops the trailing slash of a directory-form target; restore
+		// it so the redirect goes straight to the directory URL without an extra
+		// redirect hop on the website endpoint.
+		if strings.HasSuffix(record.Target, "/") && target != "/" {
+			target += "/"
+		}
 	}
 	if b.checkObjectExists(ctx, source) {
 		_, err = client.S3.CopyObject(ctx, &s3.CopyObjectInput{
@@ -127,6 +134,16 @@ func (b *Builder) redirection(ctx context.Context, record *Redirection) (err err
 		_, err = client.S3.PutObject(ctx, params)
 	}
 	return
+}
+
+// checkTargetExists reports whether an internal redirect target resolves to an
+// existing object. A directory-form target (trailing "/") resolves to its index
+// document, matching the behavior of the S3 website endpoint.
+func (b *Builder) checkTargetExists(ctx context.Context, target string) bool {
+	if strings.HasSuffix(target, "/") {
+		target += indexDocument
+	}
+	return b.checkObjectExists(ctx, target)
 }
 
 func (b *Builder) checkObjectExists(ctx context.Context, key string) bool {


### PR DESCRIPTION
## Problem

Uploading a redirection CSV with an internal **directory-form target** fails validation:

```csv
source,target
/international/wen/test/index11.html,/503/
```

The upload is rejected with *Target object not existed*, because the existence check calls `HeadObject` with the literal key `503/`, which never exists on S3 — only `503/index.html` does. Users are forced to write `/503/index.html` even though `/503/` is a perfectly valid URL on the S3 website endpoint (served via the index document rule).

## Changes

- **Validation** (`checkTargetExists`, new): a target ending in `/` now resolves to its index document (`index.html`) before the `HeadObject` existence check, matching how the S3 website endpoint serves such URLs. This also makes `/` (site root) usable as a target. The `checkObjectExists` helper is unchanged, so the source-side existence check in `redirection()` keeps its current behavior.
- **Write path** (`redirection()`): keep the trailing slash when writing `WebsiteRedirectLocation`. Previously `path.Join` collapsed `/503/` to `/503`, which costs visitors an extra redirect hop on every hit (the website endpoint 302s `/503` back to `/503/` before serving the index document).

## Tests

- `TestCheckTargetExists` — directory form resolves to index document; root resolves to index document; missing objects still rejected; no-trailing-slash paths are not treated as directories (6 cases, against a mock S3 HTTP endpoint)
- `TestRedirectionKeepsDirectoryTargetSlash` — asserts the `x-amz-website-redirect-location` actually sent to S3 keeps the trailing slash for directory-form targets and is unchanged for file / absolute-URL targets (3 cases)
- Full `./redirection` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)