### PR TITLE
fix(media): apply the Searcher to every media_libraries query

### DIFF
--- a/media/README.md
+++ b/media/README.md
@@ -1,4 +1,29 @@
 
+## Scoping the media library
+
+`Searcher` is the isolation boundary. It is applied to every `media_libraries`
+query in this package — the listing and chooser grid, folder trees, breadcrumbs,
+folder item counts, by-id reads, and the model's generic presets CRUD/search
+event funcs. Upload, new-folder and move targets are validated against it too.
+
+```go
+media.New(db).Searcher(func(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
+    return db.Where("tenant_id = ?", currentTenantID(ctx.R))
+})
+```
+
+`CurrentUserID` is **not** an isolation boundary. It only supplies a
+`user_id = ?` filter to the listing grid when no `Searcher` is configured, so
+rows stay reachable by id. That is deliberate: some roles are meant to see every
+user's uploads while the grid still defaults to their own. Configure a `Searcher`
+whenever rows must actually be isolated.
+
+Two things a `Searcher` does not cover:
+
+- `MediaBoxSetterFunc` writes whatever `MediaBox` JSON the form submits, so a
+  known URL can still be attached to a field without reading the row.
+- Anything an application queries from `media_libraries` on its own.
+
 ## Cropping logic explanation
 
 The principles of cropping are as follows

--- a/media/builder.go
+++ b/media/builder.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"slices"
+	"strconv"
 
 	"github.com/qor5/web/v3"
 	"gorm.io/gorm"
@@ -59,6 +60,52 @@ func (b *Builder) AllowTypes(v ...string) *Builder {
 func (b *Builder) Searcher(v SearchFunc) *Builder {
 	b.searcher = v
 	return b
+}
+
+// scopedDB returns a media_libraries query with the configured searcher
+// applied, so by-ID lookups and folder-tree queries see exactly the same
+// subset of rows as the listing. Without a searcher the query is unscoped,
+// preserving the historical behavior.
+func (b *Builder) scopedDB(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
+	q := db.Model(&media_library.MediaLibrary{})
+	if b.searcher != nil {
+		q = b.searcher(q, ctx)
+	}
+	return q
+}
+
+// folderIsVisible reports whether folderID may be used as an upload / move
+// target for this request: the root folder always may, and any other folder
+// only when the searcher lets the request see it. Without a searcher every id
+// is accepted, keeping the historical behavior.
+func (b *Builder) folderIsVisible(ctx *web.EventContext, folderID uint) bool {
+	if b.searcher == nil || folderID == 0 {
+		return true
+	}
+	var count int64
+	if err := b.scopedDB(b.db, ctx).Where("id = ? and folder = true", folderID).Count(&count).Error; err != nil {
+		return false
+	}
+	return count > 0
+}
+
+// recordIsVisible reports whether the row addressed by the primary-key slug id
+// is visible to this request. It backs the presets CRUD event funcs, which
+// address rows by id through the generic DataOperator and would otherwise
+// bypass the searcher entirely.
+func (b *Builder) recordIsVisible(ctx *web.EventContext, id string) bool {
+	if b.searcher == nil || id == "" {
+		return true
+	}
+	recordID, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return false
+	}
+	var count int64
+	if err := b.scopedDB(b.db, ctx).Where("id = ?", recordID).Count(&count).Error; err != nil {
+		return false
+	}
+	return count > 0
 }
 
 func (b *Builder) Activity(v *activity.Builder) *Builder {

--- a/media/builder.go
+++ b/media/builder.go
@@ -80,15 +80,20 @@ func (b *Builder) scopedDB(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
 // target for this request: the root folder always may, and any other folder
 // only when the searcher lets the request see it. Without a searcher every id
 // is accepted, keeping the historical behavior.
-func (b *Builder) folderIsVisible(ctx *web.EventContext, folderID uint) bool {
+//
+// Column names are table-qualified so that a searcher adding a Joins clause
+// cannot make them ambiguous.
+func (b *Builder) folderIsVisible(ctx *web.EventContext, folderID uint) (bool, error) {
 	if b.searcher == nil || folderID == 0 {
-		return true
+		return true, nil
 	}
 	var count int64
-	if err := b.scopedDB(b.db, ctx).Where("id = ? and folder = true", folderID).Count(&count).Error; err != nil {
-		return false
+	if err := b.scopedDB(b.db, ctx).
+		Where(qualified("id")+" = ? and "+qualified("folder")+" = true", folderID).
+		Count(&count).Error; err != nil {
+		return false, err
 	}
-	return count > 0
+	return count > 0, nil
 }
 
 // recordIsVisible reports whether the searcher lets this request see the row
@@ -96,19 +101,30 @@ func (b *Builder) folderIsVisible(ctx *web.EventContext, folderID uint) bool {
 // which address rows by id through the generic DataOperator and would otherwise
 // bypass the searcher entirely. Without a searcher every id is accepted,
 // keeping the historical behavior.
-func (b *Builder) recordIsVisible(ctx *web.EventContext, id string) bool {
+func (b *Builder) recordIsVisible(ctx *web.EventContext, id string) (bool, error) {
 	if b.searcher == nil || id == "" {
-		return true
+		return true, nil
 	}
 	recordID, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		return false
+		return false, nil
 	}
 	var count int64
-	if err := b.scopedDB(b.db, ctx).Where("id = ?", recordID).Count(&count).Error; err != nil {
-		return false
+	if err := b.scopedDB(b.db, ctx).
+		Where(qualified("id")+" = ?", recordID).
+		Count(&count).Error; err != nil {
+		return false, err
 	}
-	return count > 0
+	return count > 0, nil
+}
+
+// mediaLibrariesTable is the table GORM derives from media_library.MediaLibrary.
+const mediaLibrariesTable = "media_libraries"
+
+// qualified prefixes a media_libraries column with its table so raw conditions
+// stay unambiguous when a searcher joins another table in.
+func qualified(column string) string {
+	return mediaLibrariesTable + "." + column
 }
 
 func (b *Builder) Activity(v *activity.Builder) *Builder {

--- a/media/builder.go
+++ b/media/builder.go
@@ -89,7 +89,7 @@ func (b *Builder) folderIsVisible(ctx *web.EventContext, folderID uint) (bool, e
 	}
 	var count int64
 	if err := b.scopedDB(b.db, ctx).
-		Where(qualified("id")+" = ? and "+qualified("folder")+" = true", folderID).
+		Where("media_libraries.id = ? and media_libraries.folder = true", folderID).
 		Count(&count).Error; err != nil {
 		return false, err
 	}
@@ -111,20 +111,11 @@ func (b *Builder) recordIsVisible(ctx *web.EventContext, id string) (bool, error
 	}
 	var count int64
 	if err := b.scopedDB(b.db, ctx).
-		Where(qualified("id")+" = ?", recordID).
+		Where("media_libraries.id = ?", recordID).
 		Count(&count).Error; err != nil {
 		return false, err
 	}
 	return count > 0, nil
-}
-
-// mediaLibrariesTable is the table GORM derives from media_library.MediaLibrary.
-const mediaLibrariesTable = "media_libraries"
-
-// qualified prefixes a media_libraries column with its table so raw conditions
-// stay unambiguous when a searcher joins another table in.
-func qualified(column string) string {
-	return mediaLibrariesTable + "." + column
 }
 
 func (b *Builder) Activity(v *activity.Builder) *Builder {

--- a/media/builder.go
+++ b/media/builder.go
@@ -63,9 +63,11 @@ func (b *Builder) Searcher(v SearchFunc) *Builder {
 }
 
 // scopedDB returns a media_libraries query with the configured searcher
-// applied, so by-ID lookups and folder-tree queries see exactly the same
-// subset of rows as the listing. Without a searcher the query is unscoped,
-// preserving the historical behavior.
+// applied, so by-ID lookups and folder-tree queries see the same subset of rows
+// the searcher gives the listing. Without a searcher the query is unscoped,
+// preserving the historical behavior — including for a builder that only sets
+// CurrentUserID, whose listing-only user_id filter is deliberately not extended
+// to these queries.
 func (b *Builder) scopedDB(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
 	q := db.Model(&media_library.MediaLibrary{})
 	if b.searcher != nil {
@@ -89,10 +91,11 @@ func (b *Builder) folderIsVisible(ctx *web.EventContext, folderID uint) bool {
 	return count > 0
 }
 
-// recordIsVisible reports whether the row addressed by the primary-key slug id
-// is visible to this request. It backs the presets CRUD event funcs, which
-// address rows by id through the generic DataOperator and would otherwise
-// bypass the searcher entirely.
+// recordIsVisible reports whether the searcher lets this request see the row
+// addressed by the primary-key slug id. It backs the presets CRUD event funcs,
+// which address rows by id through the generic DataOperator and would otherwise
+// bypass the searcher entirely. Without a searcher every id is accepted,
+// keeping the historical behavior.
 func (b *Builder) recordIsVisible(ctx *web.EventContext, id string) bool {
 	if b.searcher == nil || id == "" {
 		return true

--- a/media/cropper.go
+++ b/media/cropper.go
@@ -47,10 +47,11 @@ func loadImageCropper(mb *Builder) web.EventFunc {
 			panic(err)
 		}
 
-		err = db.First(&m, id).Error
+		err = mb.scopedDB(db, ctx).First(&m, id).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			err = nil
 			presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
+			return r, nil
 		} else if err != nil {
 			return
 		}
@@ -141,14 +142,14 @@ func cropImage(b *Builder) web.EventFunc {
 				old media_library.MediaLibrary
 				m   media_library.MediaLibrary
 			)
-			err = db.First(&m, id).Error
+			err = b.scopedDB(db, ctx).First(&m, id).Error
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
 				return r, nil
 			} else if err != nil {
 				return
 			}
-			db.Find(&old, id)
+			b.scopedDB(db, ctx).Find(&old, id)
 
 			moption := m.GetMediaOption()
 			if moption.CropOptions == nil {

--- a/media/filechooser.go
+++ b/media/filechooser.go
@@ -118,6 +118,11 @@ func uploadFile(mb *Builder) web.EventFunc {
 		if err = mb.uploadIsAllowed(ctx.R); err != nil {
 			return
 		}
+		if !mb.folderIsVisible(ctx, uint(parentID)) {
+			pMsgr := i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
+			presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
+			return r, nil
+		}
 
 		var uf uploadFiles
 		ctx.MustUnmarshalForm(&uf)
@@ -181,9 +186,14 @@ func chooseFile(mb *Builder) web.EventFunc {
 		cfg := stringToCfg(ctx.Param(ParamCfg))
 
 		var m media_library.MediaLibrary
-		err = db.Find(&m, id).Error
+		err = mb.scopedDB(db, ctx).Find(&m, id).Error
 		if err != nil {
 			return
+		}
+		if m.ID == 0 {
+			pMsgr := i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
+			presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
+			return r, nil
 		}
 		sizes, needCrop := mergeNewSizes(&m, cfg)
 
@@ -388,7 +398,7 @@ func fileOrFolderComponent(
 	}
 
 	if f.Folder {
-		title, content = folderComponent(mb, f)
+		title, content = folderComponent(mb, ctx, f)
 		clickCardWithoutMoveEvent = web.Plaid().
 			EventFunc(ImageJumpPageEvent).
 			Query(ParamField, field).
@@ -451,11 +461,11 @@ func fileOrFolderComponent(
 	)
 }
 
-func folderComponent(mb *Builder, f *media_library.MediaLibrary) (title, content h.HTMLComponent) {
+func folderComponent(mb *Builder, ctx *web.EventContext, f *media_library.MediaLibrary) (title, content h.HTMLComponent) {
 	var count int64
 	fileNameComp := h.Span(f.File.FileName).Class("text-body-2").Attr("v-tooltip:bottom", h.JSONString(f.File.FileName))
 
-	mb.db.Model(media_library.MediaLibrary{}).Where("parent_id = ?", f.ID).Count(&count)
+	mb.scopedDB(mb.db, ctx).Where("parent_id = ?", f.ID).Count(&count)
 	title = VCardText(h.RawHTML(folderSvg)).Class("d-flex justify-center align-center")
 	content = h.Components(
 		web.Slot(
@@ -468,7 +478,7 @@ func folderComponent(mb *Builder, f *media_library.MediaLibrary) (title, content
 }
 
 func parentFolders(field string, ctx *web.EventContext,
-	cfg *media_library.MediaBoxConfig, db *gorm.DB, currentID, parentID uint, existed map[uint]bool, inMediaLibrary bool,
+	cfg *media_library.MediaBoxConfig, mb *Builder, currentID, parentID uint, existed map[uint]bool, inMediaLibrary bool,
 ) (comps h.HTMLComponents) {
 	if existed == nil {
 		existed = make(map[uint]bool)
@@ -480,7 +490,7 @@ func parentFolders(field string, ctx *web.EventContext,
 	if currentID == 0 {
 		return
 	}
-	if err := db.First(&current, currentID).Error; err != nil {
+	if err := mb.scopedDB(mb.db, ctx).First(&current, currentID).Error; err != nil {
 		return
 	}
 	item = VBreadcrumbsItem().Title(current.File.FileName)
@@ -497,7 +507,7 @@ func parentFolders(field string, ctx *web.EventContext,
 	}
 	comps = append(h.Components(h.Text("/")), comps...)
 	existed[currentID] = true
-	return append(parentFolders(field, ctx, cfg, db, current.ParentId, parentID, existed, inMediaLibrary), comps...)
+	return append(parentFolders(field, ctx, cfg, mb, current.ParentId, parentID, existed, inMediaLibrary), comps...)
 }
 
 func breadcrumbsItemClickEvent(field string, ctx *web.EventContext,
@@ -814,7 +824,7 @@ func mediaLibraryContent(mb *Builder, field string, ctx *web.EventContext,
 	}
 
 	if tab == tabFolders {
-		items := parentFolders(field, ctx, cfg, mb.db, uint(parentID), uint(parentID), nil, inMediaLibrary)
+		items := parentFolders(field, ctx, cfg, mb, uint(parentID), uint(parentID), nil, inMediaLibrary)
 		bc = h.If(len(items) > 0, VBreadcrumbs(
 			items...,
 		))

--- a/media/filechooser.go
+++ b/media/filechooser.go
@@ -118,7 +118,11 @@ func uploadFile(mb *Builder) web.EventFunc {
 		if err = mb.uploadIsAllowed(ctx.R); err != nil {
 			return
 		}
-		if !mb.folderIsVisible(ctx, uint(parentID)) {
+		visible, err := mb.folderIsVisible(ctx, uint(parentID))
+		if err != nil {
+			return r, err
+		}
+		if !visible {
 			pMsgr := i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 			presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
 			return r, nil
@@ -465,7 +469,7 @@ func folderComponent(mb *Builder, ctx *web.EventContext, f *media_library.MediaL
 	var count int64
 	fileNameComp := h.Span(f.File.FileName).Class("text-body-2").Attr("v-tooltip:bottom", h.JSONString(f.File.FileName))
 
-	mb.scopedDB(mb.db, ctx).Where("parent_id = ?", f.ID).Count(&count)
+	mb.scopedDB(mb.db, ctx).Where(qualified("parent_id")+" = ?", f.ID).Count(&count)
 	title = VCardText(h.RawHTML(folderSvg)).Class("d-flex justify-center align-center")
 	content = h.Components(
 		web.Slot(

--- a/media/filechooser.go
+++ b/media/filechooser.go
@@ -469,7 +469,7 @@ func folderComponent(mb *Builder, ctx *web.EventContext, f *media_library.MediaL
 	var count int64
 	fileNameComp := h.Span(f.File.FileName).Class("text-body-2").Attr("v-tooltip:bottom", h.JSONString(f.File.FileName))
 
-	mb.scopedDB(mb.db, ctx).Where(qualified("parent_id")+" = ?", f.ID).Count(&count)
+	mb.scopedDB(mb.db, ctx).Where("media_libraries.parent_id = ?", f.ID).Count(&count)
 	title = VCardText(h.RawHTML(folderSvg)).Class("d-flex justify-center align-center")
 	content = h.Components(
 		web.Slot(

--- a/media/list.go
+++ b/media/list.go
@@ -105,8 +105,8 @@ func configScopedCRUD(mb *Builder, mm *presets.ModelBuilder) {
 		return func(ctx *web.EventContext, params *presets.SearchParams) (*presets.SearchResult, error) {
 			if mb.searcher != nil {
 				params.SQLConditions = append(params.SQLConditions, &presets.SQLCondition{
-					Query: qualified("id") + " in (?)",
-					Args:  []interface{}{mb.scopedDB(mb.db, ctx).Select(qualified("id"))},
+					Query: "media_libraries.id in (?)",
+					Args:  []interface{}{mb.scopedDB(mb.db, ctx).Select("media_libraries.id")},
 				})
 			}
 			return in(ctx, params)

--- a/media/list.go
+++ b/media/list.go
@@ -17,6 +17,7 @@ const (
 func configList(b *presets.Builder, mb *Builder) {
 	mm := b.Model(&media_library.MediaLibrary{}).Label("Media Library").MenuIcon("mdi-image")
 	mb.mb = mm
+	configScopedCRUD(mb, mm)
 	oldPageFunc := mm.Listing().GetPageFunc()
 	mm.Listing().PageFunc(func(ctx *web.EventContext) (r web.PageResponse, err error) {
 		var (
@@ -42,5 +43,51 @@ func configList(b *presets.Builder, mb *Builder) {
 			),
 		)
 		return
+	})
+}
+
+// configScopedCRUD makes the model's generic CRUD event funcs respect the
+// searcher. They address rows by primary key through the DataOperator, so
+// without these guards a request could edit, delete or read back any row by id
+// regardless of what the searcher allows.
+func configScopedCRUD(mb *Builder, mm *presets.ModelBuilder) {
+	guard := func(id string, ctx *web.EventContext) error {
+		if mb.recordIsVisible(ctx, id) {
+			return nil
+		}
+		return presets.ErrRecordNotFound
+	}
+	mm.Editing().
+		WrapFetchFunc(func(in presets.FetchFunc) presets.FetchFunc {
+			return func(obj interface{}, id string, ctx *web.EventContext) (interface{}, error) {
+				if err := guard(id, ctx); err != nil {
+					return nil, err
+				}
+				return in(obj, id, ctx)
+			}
+		}).
+		WrapSaveFunc(func(in presets.SaveFunc) presets.SaveFunc {
+			return func(obj interface{}, id string, ctx *web.EventContext) error {
+				if err := guard(id, ctx); err != nil {
+					return err
+				}
+				return in(obj, id, ctx)
+			}
+		}).
+		WrapDeleteFunc(func(in presets.DeleteFunc) presets.DeleteFunc {
+			return func(obj interface{}, id string, ctx *web.EventContext) error {
+				if err := guard(id, ctx); err != nil {
+					return err
+				}
+				return in(obj, id, ctx)
+			}
+		})
+	mm.Detailing().WrapFetchFunc(func(in presets.FetchFunc) presets.FetchFunc {
+		return func(obj interface{}, id string, ctx *web.EventContext) (interface{}, error) {
+			if err := guard(id, ctx); err != nil {
+				return nil, err
+			}
+			return in(obj, id, ctx)
+		}
 	})
 }

--- a/media/list.go
+++ b/media/list.go
@@ -52,7 +52,11 @@ func configList(b *presets.Builder, mb *Builder) {
 // regardless of what the searcher allows.
 func configScopedCRUD(mb *Builder, mm *presets.ModelBuilder) {
 	guard := func(id string, ctx *web.EventContext) error {
-		if mb.recordIsVisible(ctx, id) {
+		visible, err := mb.recordIsVisible(ctx, id)
+		if err != nil {
+			return err
+		}
+		if visible {
 			return nil
 		}
 		return presets.ErrRecordNotFound
@@ -82,12 +86,30 @@ func configScopedCRUD(mb *Builder, mm *presets.ModelBuilder) {
 				return in(obj, id, ctx)
 			}
 		})
-	mm.Detailing().WrapFetchFunc(func(in presets.FetchFunc) presets.FetchFunc {
+	// GetDetailing, not Detailing: the latter would enable detailing for the
+	// model, mounting a detail route and changing listing row behavior. The
+	// detailing event funcs are registered either way, so they need the guard.
+	mm.GetDetailing().WrapFetchFunc(func(in presets.FetchFunc) presets.FetchFunc {
 		return func(obj interface{}, id string, ctx *web.EventContext) (interface{}, error) {
 			if err := guard(id, ctx); err != nil {
 				return nil, err
 			}
 			return in(obj, id, ctx)
+		}
+	})
+	// The listing's generic search backs ListingCompo, whose reload / paging /
+	// search actions stay dispatchable even though the media library replaces the
+	// listing page. Restrict it to the ids the searcher exposes; passing the
+	// scoped query as a subquery keeps a Joins-based searcher intact.
+	mm.Listing().WrapSearchFunc(func(in presets.SearchFunc) presets.SearchFunc {
+		return func(ctx *web.EventContext, params *presets.SearchParams) (*presets.SearchResult, error) {
+			if mb.searcher != nil {
+				params.SQLConditions = append(params.SQLConditions, &presets.SQLCondition{
+					Query: qualified("id") + " in (?)",
+					Args:  []interface{}{mb.scopedDB(mb.db, ctx).Select(qualified("id"))},
+				})
+			}
+			return in(ctx, params)
 		}
 	})
 }

--- a/media/media_box.go
+++ b/media/media_box.go
@@ -327,7 +327,7 @@ func doDelete(mb *Builder) web.EventFunc {
 			"vars.mediaLibrary_deleteConfirmation = false",
 			web.Plaid().EventFunc(ImageJumpPageEvent).MergeQuery(true).Queries(ctx.Queries()).Go(),
 		)
-		err = mb.scopedDB(db, ctx).Where(qualified("id")+" in ?", requestIDs).Find(&objs).Error
+		err = mb.scopedDB(db, ctx).Where("media_libraries.id in ?", requestIDs).Find(&objs).Error
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return r, nil
@@ -354,20 +354,20 @@ func doDelete(mb *Builder) web.EventFunc {
 				// scoping an UPDATE directly would silently drop the condition.
 				var childIDs []uint64
 				if dbErr = mb.scopedDB(tx, ctx).
-					Where(qualified("parent_id")+" in ?", deleteFolderIDS).
-					Pluck(qualified("id"), &childIDs).Error; dbErr != nil {
+					Where("media_libraries.parent_id in ?", deleteFolderIDS).
+					Pluck("media_libraries.id", &childIDs).Error; dbErr != nil {
 					return
 				}
 				if len(childIDs) > 0 {
 					if dbErr = tx.Model(&media_library.MediaLibrary{}).
-						Where(qualified("id")+" in ?", childIDs).
+						Where("media_libraries.id in ?", childIDs).
 						Update("parent_id", 0).Error; dbErr != nil {
 						return
 					}
 				}
 			}
 
-			if dbErr = tx.Delete(&media_library.MediaLibrary{}, qualified("id")+" in ?", visibleIDs).Error; dbErr != nil {
+			if dbErr = tx.Delete(&media_library.MediaLibrary{}, "media_libraries.id in ?", visibleIDs).Error; dbErr != nil {
 				return
 			}
 			return
@@ -711,7 +711,7 @@ func wrapFirst(mb *Builder, ctx *web.EventContext, r *web.EventResponse) (obj me
 		pMsgr = i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 	)
 
-	err = mb.scopedDB(db, ctx).Where(qualified("id")+" = ?", id).First(&obj).Error
+	err = mb.scopedDB(db, ctx).Where("media_libraries.id = ?", id).First(&obj).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			presets.ShowMessage(r, pMsgr.RecordNotFound, ColorError)
@@ -949,7 +949,7 @@ func folderGroupsComponents(mb *Builder, ctx *web.EventContext, parentID int) (i
 		records = append(records, item)
 	} else {
 		mb.scopedDB(mb.db, ctx).
-			Where(qualified("parent_id")+" = ? and "+qualified("folder")+" = true", parentID).
+			Where("media_libraries.parent_id = ? and media_libraries.folder = true", parentID).
 			Find(&records)
 	}
 	for _, record := range records {
@@ -957,7 +957,7 @@ func folderGroupsComponents(mb *Builder, ctx *web.EventContext, parentID int) (i
 			continue
 		}
 		mb.scopedDB(mb.db, ctx).
-			Where(qualified("id")+" not in ? and "+qualified("parent_id")+" = ? and "+qualified("folder")+" = true", idS, record.ID).
+			Where("media_libraries.id not in ? and media_libraries.parent_id = ? and media_libraries.folder = true", idS, record.ID).
 			Count(&count)
 		if count > 0 {
 			items = append(items,

--- a/media/media_box.go
+++ b/media/media_box.go
@@ -312,7 +312,8 @@ func doDelete(mb *Builder) web.EventFunc {
 			db              = mb.db
 			ids             = strings.Split(ctx.Param(ParamMediaIDS), ",")
 			objs            []media_library.MediaLibrary
-			deleteIDs       []uint64
+			requestIDs      []uint64
+			visibleIDs      []uint64
 			deleteFolderIDS []uint
 		)
 		for _, idStr := range ids {
@@ -320,23 +321,22 @@ func doDelete(mb *Builder) web.EventFunc {
 			if innerErr != nil {
 				continue
 			}
-			deleteIDs = append(deleteIDs, id)
+			requestIDs = append(requestIDs, id)
 		}
 		defer web.AppendRunScripts(&r,
 			"vars.mediaLibrary_deleteConfirmation = false",
 			web.Plaid().EventFunc(ImageJumpPageEvent).MergeQuery(true).Queries(ctx.Queries()).Go(),
 		)
-		err = mb.scopedDB(db, ctx).Where("id in ?", deleteIDs).Find(&objs).Error
+		err = mb.scopedDB(db, ctx).Where(qualified("id")+" in ?", requestIDs).Find(&objs).Error
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return r, nil
 			}
 			panic(err)
 		}
-		// Delete only the rows the scoped query returned, not the raw request ids.
-		deleteIDs = deleteIDs[:0]
+		// Act only on the rows the scoped query returned, not the raw request ids.
 		for _, obj := range objs {
-			deleteIDs = append(deleteIDs, uint64(obj.ID))
+			visibleIDs = append(visibleIDs, uint64(obj.ID))
 			if obj.Folder {
 				deleteFolderIDS = append(deleteFolderIDS, obj.ID)
 			}
@@ -344,18 +344,30 @@ func doDelete(mb *Builder) web.EventFunc {
 				return
 			}
 		}
-		if len(deleteIDs) == 0 {
+		if len(visibleIDs) == 0 {
 			return r, nil
 		}
 		err = db.Transaction(func(tx *gorm.DB) (dbErr error) {
 			if len(deleteFolderIDS) > 0 {
+				// Resolve the children through the scoped query and reparent them
+				// by id: GORM only applies a searcher's Joins to SELECTs, so
+				// scoping an UPDATE directly would silently drop the condition.
+				var childIDs []uint64
 				if dbErr = mb.scopedDB(tx, ctx).
-					Where("parent_id in ? ", deleteFolderIDS).Update("parent_id", 0).Error; dbErr != nil {
+					Where(qualified("parent_id")+" in ?", deleteFolderIDS).
+					Pluck(qualified("id"), &childIDs).Error; dbErr != nil {
 					return
+				}
+				if len(childIDs) > 0 {
+					if dbErr = tx.Model(&media_library.MediaLibrary{}).
+						Where(qualified("id")+" in ?", childIDs).
+						Update("parent_id", 0).Error; dbErr != nil {
+						return
+					}
 				}
 			}
 
-			if dbErr = tx.Delete(&media_library.MediaLibrary{}, "id  in ?", deleteIDs).Error; dbErr != nil {
+			if dbErr = tx.Delete(&media_library.MediaLibrary{}, qualified("id")+" in ?", visibleIDs).Error; dbErr != nil {
 				return
 			}
 			return
@@ -594,7 +606,7 @@ func updateDescription(mb *Builder) web.EventFunc {
 		if err = mb.updateDescIsAllowed(ctx.R, &obj); err != nil {
 			return
 		}
-		old, _ := wrapFirst(mb, ctx, &r)
+		old := obj
 
 		obj.File.Description = ctx.Param(ParamCurrentDescription)
 		if err = db.Save(&obj).Error; err != nil {
@@ -624,7 +636,7 @@ func rename(mb *Builder) web.EventFunc {
 		if err = mb.updateNameIsAllowed(ctx.R, &obj); err != nil {
 			return
 		}
-		old, _ := wrapFirst(mb, ctx, &r)
+		old := obj
 
 		if obj.Folder {
 			obj.File.FileName = ctx.Param(ParamName)
@@ -660,7 +672,11 @@ func createFolder(mb *Builder) web.EventFunc {
 			presets.ShowMessage(&r, "folder name can`t be empty", ColorWarning)
 			return
 		}
-		if !mb.folderIsVisible(ctx, uint(parentID)) {
+		visible, err := mb.folderIsVisible(ctx, uint(parentID))
+		if err != nil {
+			return r, err
+		}
+		if !visible {
 			pMsgr := i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 			presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
 			return
@@ -695,7 +711,7 @@ func wrapFirst(mb *Builder, ctx *web.EventContext, r *web.EventResponse) (obj me
 		pMsgr = i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 	)
 
-	err = mb.scopedDB(db, ctx).Where("id = ?", id).First(&obj).Error
+	err = mb.scopedDB(db, ctx).Where(qualified("id")+" = ?", id).First(&obj).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			presets.ShowMessage(r, pMsgr.RecordNotFound, ColorError)
@@ -861,7 +877,11 @@ func moveToFolder(mb *Builder) web.EventFunc {
 			ids = append(ids, selectID)
 		}
 		presets.ShowMessage(&r, msgr.MovedFailed, ColorError)
-		if mb.folderIsVisible(ctx, uint(selectFolderID)) && len(ids) > 0 {
+		targetVisible, err := mb.folderIsVisible(ctx, uint(selectFolderID))
+		if err != nil {
+			return r, err
+		}
+		if targetVisible && len(ids) > 0 {
 			for _, findID := range ids {
 				var old, obj media_library.MediaLibrary
 				mb.scopedDB(db, ctx).Find(&obj, findID)
@@ -928,13 +948,17 @@ func folderGroupsComponents(mb *Builder, ctx *web.EventContext, parentID int) (i
 		item.File.FileName = "Root Directory"
 		records = append(records, item)
 	} else {
-		mb.scopedDB(mb.db, ctx).Where("parent_id = ?  and folder = true", parentID).Find(&records)
+		mb.scopedDB(mb.db, ctx).
+			Where(qualified("parent_id")+" = ? and "+qualified("folder")+" = true", parentID).
+			Find(&records)
 	}
 	for _, record := range records {
 		if slices.Contains(selectIDs, fmt.Sprint(record.ID)) {
 			continue
 		}
-		mb.scopedDB(mb.db, ctx).Where("id not in ? and parent_id = ?  and folder = true", idS, record.ID).Count(&count)
+		mb.scopedDB(mb.db, ctx).
+			Where(qualified("id")+" not in ? and "+qualified("parent_id")+" = ? and "+qualified("folder")+" = true", idS, record.ID).
+			Count(&count)
 		if count > 0 {
 			items = append(items,
 				VListGroup(

--- a/media/media_box.go
+++ b/media/media_box.go
@@ -326,14 +326,17 @@ func doDelete(mb *Builder) web.EventFunc {
 			"vars.mediaLibrary_deleteConfirmation = false",
 			web.Plaid().EventFunc(ImageJumpPageEvent).MergeQuery(true).Queries(ctx.Queries()).Go(),
 		)
-		err = db.Where("id in ?", deleteIDs).Find(&objs).Error
+		err = mb.scopedDB(db, ctx).Where("id in ?", deleteIDs).Find(&objs).Error
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return r, nil
 			}
 			panic(err)
 		}
+		// Delete only the rows the scoped query returned, not the raw request ids.
+		deleteIDs = deleteIDs[:0]
 		for _, obj := range objs {
+			deleteIDs = append(deleteIDs, uint64(obj.ID))
 			if obj.Folder {
 				deleteFolderIDS = append(deleteFolderIDS, obj.ID)
 			}
@@ -341,10 +344,12 @@ func doDelete(mb *Builder) web.EventFunc {
 				return
 			}
 		}
+		if len(deleteIDs) == 0 {
+			return r, nil
+		}
 		err = db.Transaction(func(tx *gorm.DB) (dbErr error) {
 			if len(deleteFolderIDS) > 0 {
-				if dbErr = tx.
-					Model(&media_library.MediaLibrary{}).
+				if dbErr = mb.scopedDB(tx, ctx).
 					Where("parent_id in ? ", deleteFolderIDS).Update("parent_id", 0).Error; dbErr != nil {
 					return
 				}
@@ -582,11 +587,14 @@ func updateDescription(mb *Builder) web.EventFunc {
 			msgr = i18n.MustGetModuleMessages(ctx.R, I18nMediaLibraryKey, Messages_en_US).(*Messages)
 		)
 
-		obj := wrapFirst(mb, ctx, &r)
+		obj, ok := wrapFirst(mb, ctx, &r)
+		if !ok {
+			return
+		}
 		if err = mb.updateDescIsAllowed(ctx.R, &obj); err != nil {
 			return
 		}
-		old := wrapFirst(mb, ctx, &r)
+		old, _ := wrapFirst(mb, ctx, &r)
 
 		obj.File.Description = ctx.Param(ParamCurrentDescription)
 		if err = db.Save(&obj).Error; err != nil {
@@ -609,11 +617,14 @@ func rename(mb *Builder) web.EventFunc {
 			db   = mb.db
 			msgr = i18n.MustGetModuleMessages(ctx.R, I18nMediaLibraryKey, Messages_en_US).(*Messages)
 		)
-		obj := wrapFirst(mb, ctx, &r)
+		obj, ok := wrapFirst(mb, ctx, &r)
+		if !ok {
+			return
+		}
 		if err = mb.updateNameIsAllowed(ctx.R, &obj); err != nil {
 			return
 		}
-		old := wrapFirst(mb, ctx, &r)
+		old, _ := wrapFirst(mb, ctx, &r)
 
 		if obj.Folder {
 			obj.File.FileName = ctx.Param(ParamName)
@@ -649,6 +660,11 @@ func createFolder(mb *Builder) web.EventFunc {
 			presets.ShowMessage(&r, "folder name can`t be empty", ColorWarning)
 			return
 		}
+		if !mb.folderIsVisible(ctx, uint(parentID)) {
+			pMsgr := i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
+			presets.ShowMessage(&r, pMsgr.RecordNotFound, ColorError)
+			return
+		}
 		m.File.FileName = dirName
 		var uid uint
 		if mb.currentUserID != nil {
@@ -669,7 +685,7 @@ func createFolder(mb *Builder) web.EventFunc {
 	}
 }
 
-func wrapFirst(mb *Builder, ctx *web.EventContext, r *web.EventResponse) (obj media_library.MediaLibrary) {
+func wrapFirst(mb *Builder, ctx *web.EventContext, r *web.EventResponse) (obj media_library.MediaLibrary, ok bool) {
 	var (
 		err   error
 		db    = mb.db
@@ -679,7 +695,7 @@ func wrapFirst(mb *Builder, ctx *web.EventContext, r *web.EventResponse) (obj me
 		pMsgr = i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 	)
 
-	err = db.Where("id = ?", id).First(&obj).Error
+	err = mb.scopedDB(db, ctx).Where("id = ?", id).First(&obj).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			presets.ShowMessage(r, pMsgr.RecordNotFound, ColorError)
@@ -690,17 +706,20 @@ func wrapFirst(mb *Builder, ctx *web.EventContext, r *web.EventResponse) (obj me
 				mb,
 				stringToCfg(cfg),
 			)
-			return
+			return obj, false
 		}
 		panic(err)
 	}
-	return
+	return obj, true
 }
 
 func renameDialog(mb *Builder) web.EventFunc {
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
+		obj, ok := wrapFirst(mb, ctx, &r)
+		if !ok {
+			return
+		}
 		var (
-			obj   = wrapFirst(mb, ctx, &r)
 			pMsgr = i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 			msgr  = i18n.MustGetModuleMessages(ctx.R, I18nMediaLibraryKey, Messages_en_US).(*Messages)
 		)
@@ -754,7 +773,10 @@ func newFolderDialog(ctx *web.EventContext) (r web.EventResponse, err error) {
 
 func updateDescriptionDialog(mb *Builder) web.EventFunc {
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
-		obj := wrapFirst(mb, ctx, &r)
+		obj, ok := wrapFirst(mb, ctx, &r)
+		if !ok {
+			return
+		}
 		var (
 			pMsgr = i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
 			msgr  = i18n.MustGetModuleMessages(ctx.R, I18nMediaLibraryKey, Messages_en_US).(*Messages)
@@ -778,7 +800,6 @@ func updateDescriptionDialog(mb *Builder) web.EventFunc {
 }
 
 func moveToFolderDialog(mb *Builder) web.EventFunc {
-	db := mb.db
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
 		var (
 			pMsgr = i18n.MustGetModuleMessages(ctx.R, presets.CoreI18nModuleKey, Messages_en_US).(*presets.Messages)
@@ -791,7 +812,7 @@ func moveToFolderDialog(mb *Builder) web.EventFunc {
 					VCardItem(
 						VCard(
 							VList(
-								h.Components(folderGroupsComponents(db, ctx, -1)...),
+								h.Components(folderGroupsComponents(mb, ctx, -1)...),
 							).ActiveColor(ColorPrimary).BgColor(ColorGreyLighten5),
 						).Color(ColorGreyLighten5).Height(340).Class("overflow-auto"),
 					),
@@ -840,14 +861,14 @@ func moveToFolder(mb *Builder) web.EventFunc {
 			ids = append(ids, selectID)
 		}
 		presets.ShowMessage(&r, msgr.MovedFailed, ColorError)
-		if len(ids) > 0 {
+		if mb.folderIsVisible(ctx, uint(selectFolderID)) && len(ids) > 0 {
 			for _, findID := range ids {
 				var old, obj media_library.MediaLibrary
-				db.First(&obj, findID)
+				mb.scopedDB(db, ctx).Find(&obj, findID)
 				if obj.ID == 0 {
 					continue
 				}
-				db.First(&old, findID)
+				mb.scopedDB(db, ctx).Find(&old, findID)
 				obj.ParentId = uint(selectFolderID)
 				if err = db.Save(&obj).Error; err != nil {
 					return
@@ -873,18 +894,17 @@ func moveToFolder(mb *Builder) web.EventFunc {
 }
 
 func nextFolder(mb *Builder) web.EventFunc {
-	db := mb.db
 	return func(ctx *web.EventContext) (r web.EventResponse, err error) {
 		id := ctx.ParamAsInt(ParamSelectFolderID)
 		r.UpdatePortals = append(r.UpdatePortals, &web.PortalUpdate{
 			Name: folderGroupPortalName(uint(id)),
-			Body: h.Components(folderGroupsComponents(db, ctx, id)...),
+			Body: h.Components(folderGroupsComponents(mb, ctx, id)...),
 		})
 		return
 	}
 }
 
-func folderGroupsComponents(db *gorm.DB, ctx *web.EventContext, parentID int) (items []h.HTMLComponent) {
+func folderGroupsComponents(mb *Builder, ctx *web.EventContext, parentID int) (items []h.HTMLComponent) {
 	var (
 		records   []*media_library.MediaLibrary
 		count     int64
@@ -908,13 +928,13 @@ func folderGroupsComponents(db *gorm.DB, ctx *web.EventContext, parentID int) (i
 		item.File.FileName = "Root Directory"
 		records = append(records, item)
 	} else {
-		db.Where("parent_id = ?  and folder = true", parentID).Find(&records)
+		mb.scopedDB(mb.db, ctx).Where("parent_id = ?  and folder = true", parentID).Find(&records)
 	}
 	for _, record := range records {
 		if slices.Contains(selectIDs, fmt.Sprint(record.ID)) {
 			continue
 		}
-		db.Model(media_library.MediaLibrary{}).Where("id not in ? and parent_id = ?  and folder = true", idS, record.ID).Count(&count)
+		mb.scopedDB(mb.db, ctx).Where("id not in ? and parent_id = ?  and folder = true", idS, record.ID).Count(&count)
 		if count > 0 {
 			items = append(items,
 				VListGroup(

--- a/media/scope_test.go
+++ b/media/scope_test.go
@@ -479,7 +479,7 @@ func TestListingCompoReloadScoped(t *testing.T) {
 	pb.Build()
 	_, ownFile, _, foreignFile := seedScopeRows(t)
 
-	action := fmt.Sprintf(`{"compo_type":"*presets.ListingCompo","compo":{"id":"media_libraries_page","per_page":100},"injector":"media_libraries","method":"OnReload","request":"{}"}`)
+	const action = `{"compo_type":"*presets.ListingCompo","compo":{"id":"media_libraries_page","per_page":100},"injector":"media_libraries","method":"OnReload","request":"{}"}`
 	req := httptest.NewRequest(http.MethodPost, "/media-libraries?__execute_event__=__dispatch_stateful_action__",
 		strings.NewReader(url.Values{"__action__": []string{action}}.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/media/scope_test.go
+++ b/media/scope_test.go
@@ -1,0 +1,343 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/qor5/web/v3"
+	"github.com/qor5/x/v3/gormx"
+	"github.com/stretchr/testify/require"
+	h "github.com/theplant/htmlgo"
+	"gorm.io/gorm"
+
+	"github.com/qor5/admin/v3/media/media_library"
+	"github.com/qor5/admin/v3/presets"
+)
+
+var testDB *gorm.DB
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	testSuite := gormx.MustStartTestSuite(ctx)
+	defer func() {
+		if err := testSuite.Stop(context.Background()); err != nil {
+			fmt.Printf("Error during teardown: %v\n", err)
+		}
+	}()
+
+	testDB = testSuite.DB()
+	if err := AutoMigrate(testDB); err != nil {
+		panic(err)
+	}
+
+	m.Run()
+}
+
+const scopeTestUserHeader = "X-Test-User"
+
+// scopeTestBuilder scopes every query to the user id carried by the request
+// header, mimicking a multi-tenant Searcher.
+func scopeTestBuilder(t *testing.T) (*Builder, *presets.Builder) {
+	t.Helper()
+	pb := presets.New()
+	b := New(testDB).Searcher(func(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
+		userID, err := strconv.ParseUint(ctx.R.Header.Get(scopeTestUserHeader), 10, 64)
+		require.NoError(t, err, "every scoped request must carry a test user id")
+		return db.Where("user_id = ?", userID)
+	})
+	require.NoError(t, b.Install(pb))
+	return b, pb
+}
+
+func scopeEventContext(t *testing.T, pb *presets.Builder, userID uint, params url.Values) *web.EventContext {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/media-libraries?"+params.Encode(), nil)
+	req.Header.Set(scopeTestUserHeader, fmt.Sprint(userID))
+	var out *http.Request
+	pb.GetI18n().EnsureLanguage(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		out = r
+	})).ServeHTTP(httptest.NewRecorder(), req)
+	return &web.EventContext{R: out, W: httptest.NewRecorder()}
+}
+
+func mkRow(t *testing.T, userID uint, folder bool, parentID uint, name string) *media_library.MediaLibrary {
+	t.Helper()
+	m := &media_library.MediaLibrary{Folder: folder, ParentId: parentID, UserID: userID}
+	m.File.FileName = name
+	require.NoError(t, testDB.Create(m).Error)
+	return m
+}
+
+func seedScopeRows(t *testing.T) (ownFolder, ownFile, foreignFolder, foreignFile *media_library.MediaLibrary) {
+	t.Helper()
+	require.NoError(t, testDB.Exec("DELETE FROM media_libraries").Error)
+	ownFolder = mkRow(t, 1, true, 0, "own-folder")
+	ownFile = mkRow(t, 1, false, 0, "own.png")
+	foreignFolder = mkRow(t, 2, true, 0, "foreign-folder")
+	foreignFile = mkRow(t, 2, false, 0, "foreign.png")
+	return
+}
+
+func reload(t *testing.T, id uint) *media_library.MediaLibrary {
+	t.Helper()
+	var m media_library.MediaLibrary
+	require.NoError(t, testDB.First(&m, id).Error)
+	return &m
+}
+
+func TestScopedDBRestrictsByIDLookups(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+	ctx := scopeEventContext(t, pb, 1, url.Values{})
+
+	var m media_library.MediaLibrary
+	require.NoError(t, b.scopedDB(testDB, ctx).Find(&m, foreignFile.ID).Error)
+	require.Zero(t, m.ID, "foreign row must not be visible through scopedDB")
+
+	m = media_library.MediaLibrary{}
+	require.NoError(t, b.scopedDB(testDB, ctx).Find(&m, ownFile.ID).Error)
+	require.Equal(t, ownFile.ID, m.ID)
+
+	unscoped := New(testDB)
+	m = media_library.MediaLibrary{}
+	require.NoError(t, unscoped.scopedDB(testDB, ctx).Find(&m, foreignFile.ID).Error)
+	require.Equal(t, foreignFile.ID, m.ID, "without a searcher the historical unscoped behavior is preserved")
+}
+
+func TestFolderTreeScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	ownFolder, _, foreignFolder, _ := seedScopeRows(t)
+	// Children make the expandable-node counts meaningful: without them the
+	// scoped and unscoped count queries cannot differ.
+	mkRow(t, 1, false, ownFolder.ID, "own-child.png")
+	mkRow(t, 2, false, foreignFolder.ID, "foreign-child.png")
+	ctx := scopeEventContext(t, pb, 1, url.Values{})
+
+	items := folderGroupsComponents(b, ctx, 0)
+	require.Len(t, items, 1, "move-to tree must list only the current tenant's folders")
+}
+
+func TestFolderChildCountScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	ownFolder, _, _, _ := seedScopeRows(t)
+	mkRow(t, 1, false, ownFolder.ID, "own-child.png")
+	mkRow(t, 2, false, ownFolder.ID, "foreign-child-in-own-folder.png")
+	ctx := scopeEventContext(t, pb, 1, url.Values{})
+
+	_, content := folderComponent(b, ctx, ownFolder)
+	require.Contains(t, h.MustString(content, ctx.R.Context()), "1 items",
+		"folder tiles must count only the current tenant's children")
+}
+
+func TestParentFoldersScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	ownFolder, _, foreignFolder, _ := seedScopeRows(t)
+	ctx := scopeEventContext(t, pb, 1, url.Values{})
+	cfg := &media_library.MediaBoxConfig{}
+
+	require.NotEmpty(t, parentFolders("f", ctx, cfg, b, ownFolder.ID, ownFolder.ID, nil, true))
+	require.Empty(t, parentFolders("f", ctx, cfg, b, foreignFolder.ID, foreignFolder.ID, nil, true),
+		"foreign folder names must not leak into breadcrumbs")
+}
+
+func TestWrapFirstScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+
+	var r web.EventResponse
+	_, ok := wrapFirst(b, scopeEventContext(t, pb, 1, url.Values{ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)}}), &r)
+	require.False(t, ok)
+
+	obj, ok := wrapFirst(b, scopeEventContext(t, pb, 1, url.Values{ParamMediaIDS: []string{fmt.Sprint(ownFile.ID)}}), &r)
+	require.True(t, ok)
+	require.Equal(t, ownFile.ID, obj.ID)
+}
+
+func TestRenameScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, _, _, foreignFile := seedScopeRows(t)
+	var before int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Count(&before).Error)
+
+	_, err := rename(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)},
+		ParamName:     []string{"hijacked"},
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "foreign.png", reload(t, foreignFile.ID).File.FileName)
+	var after int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Count(&after).Error)
+	require.Equal(t, before, after, "a scoped-out rename must not insert a new row")
+}
+
+func TestDoDeleteScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+
+	_, err := doDelete(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)},
+	}))
+	require.NoError(t, err)
+	require.NotZero(t, reload(t, foreignFile.ID).ID, "foreign row must survive a scoped-out delete")
+
+	_, err = doDelete(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprint(ownFile.ID)},
+	}))
+	require.NoError(t, err)
+	var count int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Where("id = ?", ownFile.ID).Count(&count).Error)
+	require.Zero(t, count)
+}
+
+// A mixed batch pins that only the scoped-visible ids are deleted: deleting the
+// raw request ids would take the foreign row down with the own one.
+func TestDoDeleteScopedMixedBatch(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+
+	_, err := doDelete(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprintf("%d,%d", ownFile.ID, foreignFile.ID)},
+	}))
+	require.NoError(t, err)
+
+	var ownCount int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Where("id = ?", ownFile.ID).Count(&ownCount).Error)
+	require.Zero(t, ownCount, "own row in the batch must be deleted")
+	require.NotZero(t, reload(t, foreignFile.ID).ID, "foreign row in the same batch must survive")
+}
+
+// Deleting a folder reparents its children to root; that UPDATE must not touch
+// another tenant's rows that happen to sit under the deleted folder.
+func TestDoDeleteReparentScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	ownFolder, _, _, _ := seedScopeRows(t)
+	ownChild := mkRow(t, 1, false, ownFolder.ID, "own-child.png")
+	foreignChild := mkRow(t, 2, false, ownFolder.ID, "foreign-child.png")
+
+	_, err := doDelete(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprint(ownFolder.ID)},
+	}))
+	require.NoError(t, err)
+
+	require.Zero(t, reload(t, ownChild.ID).ParentId, "own child must be reparented to root")
+	require.Equal(t, ownFolder.ID, reload(t, foreignChild.ID).ParentId,
+		"foreign child must not be reparented by another tenant's delete")
+}
+
+func TestMoveToFolderScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	ownFolder, ownFile, foreignFolder, foreignFile := seedScopeRows(t)
+
+	move := func(userID uint, fileID, targetID uint) {
+		t.Helper()
+		_, err := moveToFolder(b)(scopeEventContext(t, pb, userID, url.Values{
+			ParamSelectIDS:      []string{fmt.Sprint(fileID)},
+			ParamSelectFolderID: []string{fmt.Sprint(targetID)},
+		}))
+		require.NoError(t, err)
+	}
+
+	move(1, ownFile.ID, foreignFolder.ID)
+	require.Zero(t, reload(t, ownFile.ID).ParentId, "own file must not move into a foreign folder")
+
+	move(1, foreignFile.ID, ownFolder.ID)
+	require.Zero(t, reload(t, foreignFile.ID).ParentId, "foreign file must not be movable")
+
+	move(1, ownFile.ID, ownFolder.ID)
+	require.Equal(t, ownFolder.ID, reload(t, ownFile.ID).ParentId)
+
+	// Unfiling back to the root folder stays possible — the target check
+	// special-cases id 0.
+	move(1, ownFile.ID, 0)
+	require.Zero(t, reload(t, ownFile.ID).ParentId, "moving to root must keep working")
+}
+
+func TestUploadAndCreateFolderRejectForeignParent(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, _, foreignFolder, _ := seedScopeRows(t)
+	var before int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Count(&before).Error)
+
+	_, err := createFolder(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamName:     []string{"sneaky"},
+		ParamParentID: []string{fmt.Sprint(foreignFolder.ID)},
+	}))
+	require.NoError(t, err)
+
+	var after int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Count(&after).Error)
+	require.Equal(t, before, after, "no row may be created under a foreign parent")
+}
+
+// Without a searcher every guard added by the scoping change must be inert, so
+// existing single-tenant apps keep working exactly as before.
+func TestNoSearcherKeepsEveryIDReachable(t *testing.T) {
+	pb := presets.New()
+	b := New(testDB)
+	require.NoError(t, b.Install(pb))
+	_, _, foreignFolder, foreignFile := seedScopeRows(t)
+	ctx := scopeEventContext(t, pb, 1, url.Values{})
+
+	require.True(t, b.folderIsVisible(ctx, foreignFolder.ID))
+	require.True(t, b.folderIsVisible(ctx, 4242), "a stale folder id stays acceptable")
+	require.True(t, b.recordIsVisible(ctx, fmt.Sprint(foreignFile.ID)))
+	require.True(t, b.recordIsVisible(ctx, "4242"))
+
+	obj, ok := wrapFirst(b, scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)},
+	}), &web.EventResponse{})
+	require.True(t, ok)
+	require.Equal(t, foreignFile.ID, obj.ID)
+
+	_, err := moveToFolder(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamSelectIDS:      []string{fmt.Sprint(foreignFile.ID)},
+		ParamSelectFolderID: []string{fmt.Sprint(foreignFolder.ID)},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, foreignFolder.ID, reload(t, foreignFile.ID).ParentId)
+}
+
+func TestChooseFileScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+
+	r, err := chooseFile(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamField:    []string{"f"},
+		ParamCfg:      []string{"{}"},
+		ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)},
+	}))
+	require.NoError(t, err)
+	require.Empty(t, r.UpdatePortals, "a foreign file must not be attachable through the chooser")
+
+	r, err = chooseFile(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamField:    []string{"f"},
+		ParamCfg:      []string{"{}"},
+		ParamMediaIDS: []string{fmt.Sprint(ownFile.ID)},
+	}))
+	require.NoError(t, err)
+	require.NotEmpty(t, r.UpdatePortals, "an own file must still be attachable")
+}
+
+func TestCropImageScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, _, _, foreignFile := seedScopeRows(t)
+	params := url.Values{
+		ParamField:    []string{"f"},
+		ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)},
+		"thumb":       []string{"original"},
+		"cfg":         []string{"{}"},
+		"CropOption":  []string{`{"x":0,"y":0,"width":10,"height":10}`},
+		"f.Values":    []string{"{}"},
+	}
+
+	_, err := cropImage(b)(scopeEventContext(t, pb, 1, params))
+	require.NoError(t, err)
+	require.Empty(t, reload(t, foreignFile.ID).File.CropID,
+		"a foreign image must not be re-cropped")
+}

--- a/media/scope_test.go
+++ b/media/scope_test.go
@@ -52,7 +52,7 @@ func scopeTestBuilder(t *testing.T) (*Builder, *presets.Builder) {
 	b := New(testDB).Searcher(func(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
 		userID, err := strconv.ParseUint(ctx.R.Header.Get(scopeTestUserHeader), 10, 64)
 		require.NoError(t, err, "every scoped request must carry a test user id")
-		return db.Where(qualified("user_id")+" = ?", userID)
+		return db.Where("media_libraries.user_id = ?", userID)
 	})
 	require.NoError(t, b.Install(pb))
 	return b, pb
@@ -77,7 +77,7 @@ INSERT INTO scope_test_owners (user_id) VALUES (1) ON CONFLICT DO NOTHING`).Erro
 		userID, err := strconv.ParseUint(ctx.R.Header.Get(scopeTestUserHeader), 10, 64)
 		require.NoError(t, err, "every scoped request must carry a test user id")
 		return db.
-			Joins("join scope_test_owners on scope_test_owners.user_id = "+qualified("user_id")).
+			Joins("join scope_test_owners on scope_test_owners.user_id = media_libraries.user_id").
 			Where("scope_test_owners.user_id = ?", userID)
 	})
 	require.NoError(t, b.Install(pb))

--- a/media/scope_test.go
+++ b/media/scope_test.go
@@ -7,16 +7,20 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/qor5/web/v3"
 	"github.com/qor5/x/v3/gormx"
+	"github.com/qor5/x/v3/i18n"
 	"github.com/stretchr/testify/require"
 	h "github.com/theplant/htmlgo"
 	"gorm.io/gorm"
 
+	"github.com/qor5/admin/v3/media/base"
 	"github.com/qor5/admin/v3/media/media_library"
 	"github.com/qor5/admin/v3/presets"
+	"github.com/qor5/admin/v3/presets/gorm2op"
 )
 
 var testDB *gorm.DB
@@ -44,11 +48,37 @@ const scopeTestUserHeader = "X-Test-User"
 // header, mimicking a multi-tenant Searcher.
 func scopeTestBuilder(t *testing.T) (*Builder, *presets.Builder) {
 	t.Helper()
-	pb := presets.New()
+	pb := presets.New().DataOperator(gorm2op.DataOperator(testDB))
 	b := New(testDB).Searcher(func(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
 		userID, err := strconv.ParseUint(ctx.R.Header.Get(scopeTestUserHeader), 10, 64)
 		require.NoError(t, err, "every scoped request must carry a test user id")
-		return db.Where("user_id = ?", userID)
+		return db.Where(qualified("user_id")+" = ?", userID)
+	})
+	require.NoError(t, b.Install(pb))
+	return b, pb
+}
+
+// scopeTestJoinBuilder scopes through a Joins clause, which is what makes
+// unqualified column conditions ambiguous and silently drops from UPDATEs.
+func scopeTestJoinBuilder(t *testing.T) (*Builder, *presets.Builder) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(`
+CREATE TABLE IF NOT EXISTS scope_test_owners (user_id bigint primary key)`).Error)
+	require.NoError(t, testDB.Exec(`
+INSERT INTO scope_test_owners (user_id) VALUES (1) ON CONFLICT DO NOTHING`).Error)
+	t.Cleanup(func() {
+		if err := testDB.Exec(`DROP TABLE IF EXISTS scope_test_owners`).Error; err != nil {
+			t.Errorf("drop owners table: %v", err)
+		}
+	})
+
+	pb := presets.New().DataOperator(gorm2op.DataOperator(testDB))
+	b := New(testDB).Searcher(func(db *gorm.DB, ctx *web.EventContext) *gorm.DB {
+		userID, err := strconv.ParseUint(ctx.R.Header.Get(scopeTestUserHeader), 10, 64)
+		require.NoError(t, err, "every scoped request must carry a test user id")
+		return db.
+			Joins("join scope_test_owners on scope_test_owners.user_id = "+qualified("user_id")).
+			Where("scope_test_owners.user_id = ?", userID)
 	})
 	require.NoError(t, b.Install(pb))
 	return b, pb
@@ -258,7 +288,7 @@ func TestMoveToFolderScoped(t *testing.T) {
 	require.Zero(t, reload(t, ownFile.ID).ParentId, "moving to root must keep working")
 }
 
-func TestUploadAndCreateFolderRejectForeignParent(t *testing.T) {
+func TestCreateFolderRejectsForeignParent(t *testing.T) {
 	b, pb := scopeTestBuilder(t)
 	_, _, foreignFolder, _ := seedScopeRows(t)
 	var before int64
@@ -275,19 +305,78 @@ func TestUploadAndCreateFolderRejectForeignParent(t *testing.T) {
 	require.Equal(t, before, after, "no row may be created under a foreign parent")
 }
 
+// uploadFile checks the parent before it touches the multipart body, so an
+// empty request is enough to pin the guard.
+func TestUploadFileRejectsForeignParent(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	ownFolder, _, foreignFolder, _ := seedScopeRows(t)
+	msgr := i18n.MustGetModuleMessages(
+		scopeEventContext(t, pb, 1, url.Values{}).R, presets.CoreI18nModuleKey, presets.Messages_en_US,
+	).(*presets.Messages)
+
+	r, err := uploadFile(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamField:    []string{"f"},
+		ParamCfg:      []string{"{}"},
+		ParamParentID: []string{fmt.Sprint(foreignFolder.ID)},
+	}))
+	require.NoError(t, err)
+	require.Contains(t, r.RunScript, msgr.RecordNotFound, "upload into a foreign folder must be refused")
+
+	r, err = uploadFile(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamField:    []string{"f"},
+		ParamCfg:      []string{"{}"},
+		ParamParentID: []string{fmt.Sprint(ownFolder.ID)},
+	}))
+	require.NoError(t, err)
+	require.NotContains(t, r.RunScript, msgr.RecordNotFound, "upload into an own folder must pass the guard")
+}
+
+// loadImageCropper returns early on a scoped-out record instead of rendering a
+// cropper for a zero-value row.
+func TestLoadImageCropperScoped(t *testing.T) {
+	b, pb := scopeTestBuilder(t)
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+	params := func(id uint) url.Values {
+		return url.Values{
+			ParamField:    []string{"f"},
+			ParamMediaIDS: []string{fmt.Sprint(id)},
+			"thumb":       []string{base.DefaultSizeKey},
+			"cfg":         []string{"{}"},
+			"f.Values":    []string{"{}"},
+		}
+	}
+
+	r, err := loadImageCropper(b)(scopeEventContext(t, pb, 1, params(foreignFile.ID)))
+	require.NoError(t, err)
+	require.Empty(t, r.UpdatePortals, "no cropper may be rendered for a foreign image")
+
+	r, err = loadImageCropper(b)(scopeEventContext(t, pb, 1, params(ownFile.ID)))
+	require.NoError(t, err)
+	require.NotEmpty(t, r.UpdatePortals, "an own image must still open the cropper")
+}
+
 // Without a searcher every guard added by the scoping change must be inert, so
 // existing single-tenant apps keep working exactly as before.
 func TestNoSearcherKeepsEveryIDReachable(t *testing.T) {
-	pb := presets.New()
+	pb := presets.New().DataOperator(gorm2op.DataOperator(testDB))
 	b := New(testDB)
 	require.NoError(t, b.Install(pb))
 	_, _, foreignFolder, foreignFile := seedScopeRows(t)
 	ctx := scopeEventContext(t, pb, 1, url.Values{})
 
-	require.True(t, b.folderIsVisible(ctx, foreignFolder.ID))
-	require.True(t, b.folderIsVisible(ctx, 4242), "a stale folder id stays acceptable")
-	require.True(t, b.recordIsVisible(ctx, fmt.Sprint(foreignFile.ID)))
-	require.True(t, b.recordIsVisible(ctx, "4242"))
+	requireVisible := func(msg string, visible bool, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		require.True(t, visible, msg)
+	}
+	visible, err := b.folderIsVisible(ctx, foreignFolder.ID)
+	requireVisible("a foreign folder stays an acceptable target", visible, err)
+	visible, err = b.folderIsVisible(ctx, 4242)
+	requireVisible("a stale folder id stays acceptable", visible, err)
+	visible, err = b.recordIsVisible(ctx, fmt.Sprint(foreignFile.ID))
+	requireVisible("a foreign row stays reachable by id", visible, err)
+	visible, err = b.recordIsVisible(ctx, "4242")
+	requireVisible("an unknown id stays acceptable", visible, err)
 
 	obj, ok := wrapFirst(b, scopeEventContext(t, pb, 1, url.Values{
 		ParamMediaIDS: []string{fmt.Sprint(foreignFile.ID)},
@@ -295,7 +384,7 @@ func TestNoSearcherKeepsEveryIDReachable(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, foreignFile.ID, obj.ID)
 
-	_, err := moveToFolder(b)(scopeEventContext(t, pb, 1, url.Values{
+	_, err = moveToFolder(b)(scopeEventContext(t, pb, 1, url.Values{
 		ParamSelectIDS:      []string{fmt.Sprint(foreignFile.ID)},
 		ParamSelectFolderID: []string{fmt.Sprint(foreignFolder.ID)},
 	}))
@@ -340,4 +429,110 @@ func TestCropImageScoped(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, reload(t, foreignFile.ID).File.CropID,
 		"a foreign image must not be re-cropped")
+}
+
+// serveEvent drives a presets event func through the presets handler, so the
+// generic CRUD guards are exercised the way a real request reaches them.
+func serveEvent(t *testing.T, pb *presets.Builder, userID uint, params url.Values) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/media-libraries?"+params.Encode(), http.NoBody)
+	req.Header.Set(scopeTestUserHeader, fmt.Sprint(userID))
+	rec := httptest.NewRecorder()
+	pb.ServeHTTP(rec, req)
+	return rec.Body.String()
+}
+
+// The model's generic presets event funcs address rows by primary key through
+// the DataOperator, bypassing the media event funcs entirely.
+func TestPresetsCRUDEventsScoped(t *testing.T) {
+	_, pb := scopeTestBuilder(t)
+	pb.Build()
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+
+	body := serveEvent(t, pb, 1, url.Values{
+		"__execute_event__": []string{"presets_DoDelete"},
+		"id":                []string{fmt.Sprint(foreignFile.ID)},
+	})
+	require.Contains(t, body, "record not found")
+	require.NotZero(t, reload(t, foreignFile.ID).ID, "a foreign row must survive presets_DoDelete")
+
+	body = serveEvent(t, pb, 1, url.Values{
+		"__execute_event__": []string{"presets_DetailingDrawer"},
+		"id":                []string{fmt.Sprint(foreignFile.ID)},
+	})
+	require.NotContains(t, body, foreignFile.File.FileName, "presets_DetailingDrawer must not read a foreign row back")
+
+	body = serveEvent(t, pb, 1, url.Values{
+		"__execute_event__": []string{"presets_DoDelete"},
+		"id":                []string{fmt.Sprint(ownFile.ID)},
+	})
+	require.NotContains(t, body, "record not found")
+	var count int64
+	require.NoError(t, testDB.Model(&media_library.MediaLibrary{}).Where("id = ?", ownFile.ID).Count(&count).Error)
+	require.Zero(t, count, "an own row must still be deletable through presets_DoDelete")
+}
+
+// ListingCompo actions stay dispatchable even though the media library replaces
+// the listing page, so the listing's generic search needs scoping too.
+func TestListingCompoReloadScoped(t *testing.T) {
+	_, pb := scopeTestBuilder(t)
+	pb.Build()
+	_, ownFile, _, foreignFile := seedScopeRows(t)
+
+	action := fmt.Sprintf(`{"compo_type":"*presets.ListingCompo","compo":{"id":"media_libraries_page","per_page":100},"injector":"media_libraries","method":"OnReload","request":"{}"}`)
+	req := httptest.NewRequest(http.MethodPost, "/media-libraries?__execute_event__=__dispatch_stateful_action__",
+		strings.NewReader(url.Values{"__action__": []string{action}}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(scopeTestUserHeader, "1")
+	rec := httptest.NewRecorder()
+	pb.ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	rowLink := func(id uint) string {
+		// Row click renders as presets_Edit with the id as a query, JSON-escaped.
+		return fmt.Sprintf(`query(\"id\", \"%d\")`, id)
+	}
+	require.NotContains(t, body, rowLink(foreignFile.ID),
+		"the listing must not enumerate a foreign row")
+	require.Contains(t, body, rowLink(ownFile.ID),
+		"the listing must still enumerate own rows")
+}
+
+// Installing media must not enable detailing for the model: that would mount a
+// detail route and change how listing rows behave for every app.
+func TestInstallDoesNotEnableDetailing(t *testing.T) {
+	b, _ := scopeTestBuilder(t)
+	require.False(t, b.GetPresetsModelBuilder().HasDetailing(),
+		"configScopedCRUD must guard detailing without enabling it")
+}
+
+// A Joins-based searcher is the case that breaks unqualified conditions and
+// silently drops from UPDATEs.
+func TestJoinSearcherScoped(t *testing.T) {
+	b, pb := scopeTestJoinBuilder(t)
+	ownFolder, ownFile, _, foreignFile := seedScopeRows(t)
+	ownChild := mkRow(t, 1, false, ownFolder.ID, "own-child.png")
+	foreignChild := mkRow(t, 2, false, ownFolder.ID, "foreign-child.png")
+	ctx := scopeEventContext(t, pb, 1, url.Values{})
+
+	visible, err := b.folderIsVisible(ctx, ownFolder.ID)
+	require.NoError(t, err, "a join searcher must not make the condition ambiguous")
+	require.True(t, visible, "an own folder must stay usable as a target")
+
+	visible, err = b.recordIsVisible(ctx, fmt.Sprint(ownFile.ID))
+	require.NoError(t, err)
+	require.True(t, visible)
+
+	visible, err = b.recordIsVisible(ctx, fmt.Sprint(foreignFile.ID))
+	require.NoError(t, err)
+	require.False(t, visible)
+
+	// Deleting the folder reparents children; the scope must survive the write.
+	_, err = doDelete(b)(scopeEventContext(t, pb, 1, url.Values{
+		ParamMediaIDS: []string{fmt.Sprint(ownFolder.ID)},
+	}))
+	require.NoError(t, err)
+	require.Zero(t, reload(t, ownChild.ID).ParentId, "own child must be reparented to root")
+	require.Equal(t, ownFolder.ID, reload(t, foreignChild.ID).ParentId,
+		"foreign child must not be reparented by another tenant's delete")
 }

--- a/media/scope_test.go
+++ b/media/scope_test.go
@@ -56,7 +56,7 @@ func scopeTestBuilder(t *testing.T) (*Builder, *presets.Builder) {
 
 func scopeEventContext(t *testing.T, pb *presets.Builder, userID uint, params url.Values) *web.EventContext {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/media-libraries?"+params.Encode(), nil)
+	req := httptest.NewRequest(http.MethodPost, "/media-libraries?"+params.Encode(), http.NoBody)
 	req.Header.Set(scopeTestUserHeader, fmt.Sprint(userID))
 	var out *http.Request
 	pb.GetI18n().EnsureLanguage(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {

--- a/presets/model.go
+++ b/presets/model.go
@@ -77,6 +77,14 @@ func (mb *ModelBuilder) HasDetailing() bool {
 	return mb.hasDetailing
 }
 
+// GetDetailing returns the detailing builder without enabling detailing for the
+// model. Detailing event funcs are registered whether or not detailing is
+// enabled, so use this to configure them — Detailing() sets hasDetailing, which
+// mounts a detail route and changes how listing rows behave.
+func (mb *ModelBuilder) GetDetailing() *DetailingBuilder {
+	return mb.detailing
+}
+
 func (mb *ModelBuilder) GetSingleton() bool {
 	return mb.singleton
 }


### PR DESCRIPTION
## Problem

`media.Builder.Searcher` is the only hook an app has to scope the media library (multi-tenant isolation, per-team libraries, …), but it was applied in exactly one place: `mediaLibraryFilter`, which backs the listing grid, the chooser dialog, search and pagination.

Every other query in the package addressed rows by id or parent id straight off the request and never consulted the searcher. With a searcher configured for data isolation, a request could still reach rows outside its scope:

| Path | Effect |
|---|---|
| `chooseFile` (`filechooser.go`) | read back **any** row by id (url, filename, description) and attach it |
| `loadImageCropper` / `cropImage` (`cropper.go`) | load **and overwrite** any image by id |
| `folderGroupsComponents` (`media_box.go`) | Move-to dialog tree lists **all** folders; expansion counts all children |
| `moveToFolder` | move target not validated; rows fetched by raw id |
| `parentFolders` (`filechooser.go`) | breadcrumbs resolve arbitrary parent ids |
| `folderComponent` (`filechooser.go`) | folder tiles count foreign children |
| `wrapFirst` → rename / update-description | read rows by raw id |
| `doDelete` | deletes the **raw request ids**; reparents children of deleted folders unscoped |
| presets `Edit` / `Update` / `DoDelete` / `DetailingDrawer` | the model's generic CRUD event funcs address rows by primary key through the `DataOperator` |

## Change

- **`Builder.scopedDB(db, ctx)`** — a `media_libraries` query with the searcher applied. Every read/write listed above now goes through it.
- **`Builder.folderIsVisible(ctx, id)`** — validates an upload / new-folder / move target: root is always allowed, any other folder only when the searcher lets the request see it.
- **`Builder.recordIsVisible(ctx, id)`** — backs new `WrapFetchFunc` / `WrapSaveFunc` / `WrapDeleteFunc` guards on the model's editing and detailing builders, and a `WrapSearchFunc` guard on its listing, so the generic CRUD and listing events cannot address or enumerate out-of-scope rows. Detailing is reached through the new `presets.ModelBuilder.GetDetailing()` so that installing media does not enable detailing.
- `doDelete` now deletes only the ids its scoped read returned, and scopes the child-reparenting `UPDATE`.

## Not covered by a Searcher

`MediaBoxSetterFunc` persists whatever `MediaBox` JSON a form submits, so someone who already knows a URL can still attach it to a field without reading the row. Scoping the reads does not change that, and this PR does not attempt to. Both this and app-side queries against `media_libraries` are called out in `media/README.md`.

## Backward compatibility

**With no `Searcher` configured every guard is inert** — `scopedDB` adds no predicate and both `*IsVisible` helpers return true, so behavior is unchanged. `TestNoSearcherKeepsEveryIDReachable` pins this (foreign ids, stale folder ids and a move to a foreign folder all still work).

Two deliberate changes apply in that case as well, both of the same class — an event func no longer proceeds with a zero-value `MediaLibrary` when the record is missing:

1. `wrapFirst` gained an `ok` return. Previously an `ErrRecordNotFound` left a zero-id object that `rename` / `updateDescription` then `Save`d, **inserting a garbage row**.
2. `chooseFile` and `loadImageCropper` return early on a missing record instead of rendering a chooser/cropper for a zero-value row.

## Tests

New `media/scope_test.go` (14 tests, `gormx` test suite like `activity`): by-id lookups, folder tree, folder child counts, breadcrumbs, `wrapFirst`, rename, delete (incl. a **mixed own+foreign batch** and folder-child reparenting), move-to-folder (incl. move-to-root), foreign-parent upload/new-folder rejection, `chooseFile`, `cropImage`, and the no-searcher compatibility contract.

```
go test ./media   # ok, 14 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
